### PR TITLE
Add Unity 2019.3.9f1-2019.4.1f1

### DIFF
--- a/build_all.bat
+++ b/build_all.bat
@@ -195,4 +195,12 @@ call group5\build.bat 2019.3.5f1
 call group5\build.bat 2019.3.6f1
 call group5\build.bat 2019.3.7f1
 call group5\build.bat 2019.3.8f1
+call group5\build.bat 2019.3.9f1
+call group5\build.bat 2019.3.10f1
+call group5\build.bat 2019.3.11f1
+call group5\build.bat 2019.3.12f1
+call group5\build.bat 2019.3.13f1
+call group5\build.bat 2019.3.14f1
+call group5\build.bat 2019.4.0f1
+call group5\build.bat 2019.4.1f1
 pause

--- a/extract.sh
+++ b/extract.sh
@@ -38,7 +38,7 @@ done
 extract 2018.3.0f2 Editor/data/Mono group4/Mono
 extract 2018.3.0f2 Editor/data/MonoBleedingEdge group4/MonoBleedingEdge
 
-for i in 2019.3.0f6 2019.3.1f1 2019.3.2f1 2019.3.3f1 2019.3.4f1 2019.3.5f1 2019.3.6f1 2019.3.7f1 2019.3.8f1
+for i in 2019.3.0f6 2019.3.1f1 2019.3.2f1 2019.3.3f1 2019.3.4f1 2019.3.5f1 2019.3.6f1 2019.3.7f1 2019.3.8f1 2019.3.9f1 2019.3.10f1 2019.3.11f1 2019.3.12f1 2019.3.13f1 2019.3.14f1 2019.4.0f1 2019.4.1f1
 do
     extract $i Editor/data/il2cpp group5/il2cpp-$i
 done

--- a/headers/2019.3.10f1.h
+++ b/headers/2019.3.10f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/headers/2019.3.11f1.h
+++ b/headers/2019.3.11f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/headers/2019.3.12f1.h
+++ b/headers/2019.3.12f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/headers/2019.3.14f1.h
+++ b/headers/2019.3.14f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/headers/2019.3.9f1.h
+++ b/headers/2019.3.9f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/headers/2019.4.0f1.h
+++ b/headers/2019.4.0f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/headers/2019.4.1f1.h
+++ b/headers/2019.4.1f1.h
@@ -1,0 +1,1496 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+
+struct MonitorData;
+struct Il2CppObject {
+    struct Il2CppClass *klass;
+    struct MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds {
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray {
+    struct Il2CppObject obj;
+    struct Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    /* vector must be 8-byte aligned.
+       On 64-bit platforms, this happens naturally.
+       On 32-bit platforms, sizeof(obj)=8, sizeof(bounds)=4 and sizeof(max_length)=4 so it's also already aligned. */
+    void *vector[32];
+};
+struct Il2CppString {
+    struct Il2CppObject object;
+    int32_t length;
+    uint16_t chars[32];
+};

--- a/notes.md
+++ b/notes.md
@@ -208,6 +208,14 @@
 24.3: (provisional name)
     2019.3.7f1 * (+Il2CppCodeRegistration.windowsRuntimeFactoryCount)
     2019.3.8f1
+    2019.3.9f1
+    2019.3.10f1
+    2019.3.11f1
+    2019.3.12f1
+    2019.3.13f1
+    2019.3.14f1
+    2019.4.0f1
+    2019.4.1f1
 ```
 
 ## Milestones


### PR DESCRIPTION
This adds/changes the relevant files to include the above Unity versions. Mostly just to make sure I'm doing it correctly :)

There were no changes to any of the new versions after running diffs.py so no further work to do I think?