### PR TITLE
Don't output timestamps in diff files

### DIFF
--- a/api/diffs.diff
+++ b/api/diffs.diff
@@ -1,14 +1,14 @@
---- 5.3.0f4.h	2020-07-25 04:44:17.101453200 +0200
-+++ 5.3.1f1.h	2020-07-25 04:44:17.134959300 +0200
+--- 5.3.0f4.h
++++ 5.3.1f1.h
 @@ -224,0 +225,2 @@
 +DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
 +
---- 5.3.1f1.h	2020-07-25 04:44:17.134959300 +0200
-+++ 5.3.2f1.h	2020-07-25 04:44:17.167964800 +0200
+--- 5.3.1f1.h
++++ 5.3.2f1.h
 @@ -40,0 +41 @@
 +DO_API( TypeInfo*, il2cpp_class_get_nested_types, (TypeInfo *klass, void* *iter) );
---- 5.3.4f1.h	2020-07-25 04:44:17.234976600 +0200
-+++ 5.3.5f1.h	2020-07-25 04:44:17.270482900 +0200
+--- 5.3.4f1.h
++++ 5.3.5f1.h
 @@ -8,3 +8,3 @@
 -DO_API( Il2CppImage*, il2cpp_get_corlib, () );
 -DO_API( void, il2cpp_add_internal_call, (const char* name, methodPointerType method) );
@@ -173,8 +173,8 @@
 @@ -240 +243 @@
 -DO_API( const TypeInfo*, il2cpp_debug_local_get_type, (const Il2CppDebugLocalsInfo *info) );
 +DO_API( const Il2CppClass*, il2cpp_debug_local_get_type, (const Il2CppDebugLocalsInfo *info) );
---- 5.3.5f1.h	2020-07-25 04:44:17.270482900 +0200
-+++ 5.3.6f1.h	2020-07-25 04:44:17.306489000 +0200
+--- 5.3.5f1.h
++++ 5.3.6f1.h
 @@ -138,0 +139,2 @@
 +#if IL2CPP_ENABLE_PROFILER
 +
@@ -187,8 +187,8 @@
 @@ -189 +193 @@
 -DO_API( Il2CppString*, il2cpp_string_new_utf16, (const uint16_t *text, int32_t len) );
 +DO_API( Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar *text, int32_t len) );
---- 5.4.6f3.h	2020-07-25 04:44:17.617043100 +0200
-+++ 5.5.0f3.h	2020-07-25 04:44:17.651049200 +0200
+--- 5.4.6f3.h
++++ 5.5.0f3.h
 @@ -2,0 +3 @@
 +DO_API( void, il2cpp_init_utf16, (const Il2CppChar* domain_name) );
 @@ -6 +7,5 @@
@@ -203,22 +203,22 @@
 -// delegate
 -DO_API( Il2CppAsyncResult*, il2cpp_delegate_begin_invoke, (Il2CppDelegate* delegate, void** params, Il2CppDelegate* asyncCallback, Il2CppObject* state) );
 -DO_API( Il2CppObject*, il2cpp_delegate_end_invoke, (Il2CppAsyncResult* asyncResult, void **out_args) );
---- 5.5.6f1.h	2020-07-25 04:44:17.857085000 +0200
-+++ 5.6.0f3.h	2020-07-25 04:44:17.890590500 +0200
+--- 5.5.6f1.h
++++ 5.6.0f3.h
 @@ -104,0 +106 @@
 +DO_API( void, il2cpp_field_set_value_object, (Il2CppObject *instance, FieldInfo *field, Il2CppObject *value));
 @@ -234,0 +237,3 @@
 +// Logging
 +DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
 +
---- 5.6.7f1.h	2020-07-25 04:44:18.132132500 +0200
-+++ 2017.1.0f3.h	2020-07-25 04:44:15.621195800 +0200
+--- 5.6.7f1.h
++++ 2017.1.0f3.h
 @@ -5,0 +6 @@
 +DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
 @@ -59,0 +61 @@
 +DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
---- 2017.1.5f1.h	2020-07-25 04:44:15.796726100 +0200
-+++ 2017.2.0f3.h	2020-07-25 04:44:15.832732500 +0200
+--- 2017.1.5f1.h
++++ 2017.2.0f3.h
 @@ -0,0 +1,5 @@
 +#ifndef DO_API_NO_RETURN
 +#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
@@ -228,8 +228,8 @@
 @@ -88 +93 @@
 -DO_API(void, il2cpp_raise_exception, (Il2CppException*));
 +DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
---- 2017.2.5f1.h	2020-07-25 04:44:16.012264000 +0200
-+++ 2017.3.0f3.h	2020-07-25 04:44:16.048269900 +0200
+--- 2017.2.5f1.h
++++ 2017.3.0f3.h
 @@ -157,0 +158 @@
 +DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
 @@ -245,24 +245,0 @@
@@ -257,8 +257,8 @@
 -DO_API(void, il2cpp_debug_method_clear_breakpoint_data, (const Il2CppDebugMethodInfo * info));
 -DO_API(void, il2cpp_debug_method_clear_breakpoint_data_at, (const Il2CppDebugMethodInfo * info, uint64_t location));
 -#endif
---- 2017.4.40f1.h	2020-07-25 04:44:18.415682000 +0200
-+++ 2018.1.0f2.h	2020-07-25 04:44:18.668726200 +0200
+--- 2017.4.40f1.h
++++ 2018.1.0f2.h
 @@ -72,0 +73 @@
 +DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
 @@ -77,0 +79 @@
@@ -281,8 +281,8 @@
 +
 +// Debugger
 +DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
---- 2018.1.9f2.h	2020-07-25 04:44:19.006784800 +0200
-+++ 2018.2.0f2.h	2020-07-25 04:44:19.045291600 +0200
+--- 2018.1.9f2.h
++++ 2018.2.0f2.h
 @@ -139,0 +140 @@
 +DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
 @@ -232,0 +234 @@
@@ -294,8 +294,8 @@
 +
 +// TLS module
 +DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
---- 2018.2.21f1.h	2020-07-25 04:44:19.536377100 +0200
-+++ 2018.3.0f2.h	2020-07-25 04:44:19.881937000 +0200
+--- 2018.2.21f1.h
++++ 2018.3.0f2.h
 @@ -120,0 +121 @@
 +DO_API(bool, il2cpp_gc_is_disabled, ());
 @@ -122,0 +124 @@
@@ -317,8 +317,8 @@
 +DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
 +
 +DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
---- 2018.4.25f1.h	2020-07-25 04:44:21.094148300 +0200
-+++ 2019.1.0f2.h	2020-07-25 04:44:21.438207700 +0200
+--- 2018.4.25f1.h
++++ 2019.1.0f2.h
 @@ -5,3 +5,2 @@
 -
 -DO_API(void, il2cpp_init, (const char* domain_name));
@@ -338,8 +338,8 @@
 +// Il2CppClass user data for GetComponent optimization
 +DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
 +DO_API(int, il2cpp_class_get_userdata_offset, ());
---- 2019.2.21f1.h	2020-07-25 04:44:22.560903300 +0200
-+++ 2019.3.0f6.h	2020-07-25 04:44:22.920466000 +0200
+--- 2019.2.21f1.h
++++ 2019.3.0f6.h
 @@ -37,0 +38 @@
 +DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
 @@ -57,0 +59 @@
@@ -374,12 +374,12 @@
 +
 +// Debug metadata
 +DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
---- 2019.3.15f1.h	2020-07-25 04:44:23.161507900 +0200
-+++ 2019.4.0f1.h	2020-07-25 04:44:23.567578600 +0200
+--- 2019.3.15f1.h
++++ 2019.4.0f1.h
 @@ -304,0 +305,2 @@
 +
 +DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));
---- 2019.4.5f1.h	2020-07-25 04:44:23.770614000 +0200
-+++ 2020.1.0f1.h	2020-07-25 04:44:23.810120800 +0200
+--- 2019.4.6f1.h
++++ 2020.1.0f1.h
 @@ -103,0 +104 @@
 +DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID));

--- a/api/diffs.sh
+++ b/api/diffs.sh
@@ -2,5 +2,5 @@ vers=($(ls *.h | sort -t. -k1,1n -k2,2n -k3,3n))
 rm -f diffs.diff
 for ((i=0; i<${#vers[@]}-1; i++)); do
     echo ${vers[i]} .. ${vers[i+1]}
-    diff -wBu0 ${vers[i]} ${vers[i+1]} >> diffs.diff
+    diff -wBu0 --label=${vers[i]} --label=${vers[i+1]} ${vers[i]} ${vers[i+1]} >> diffs.diff
 done

--- a/headers/diffs.diff
+++ b/headers/diffs.diff
@@ -1,5 +1,5 @@
---- 5.3.1f1.h	2020-07-25 04:44:17.132958800 +0200
-+++ 5.3.2f1.h	2020-07-25 04:44:17.165964700 +0200
+--- 5.3.1f1.h
++++ 5.3.2f1.h
 @@ -77,13 +77,23 @@ const GenericParameterIndex kGenericPara
  const RGCTXIndex kRGCTXIndexInvalid = -1;
  const StringLiteralIndex kStringLiteralIndexInvalid = -1;
@@ -191,8 +191,8 @@
  } Il2CppMetadataRegistration;
  typedef struct Il2CppRuntimeStats
  {
---- 5.3.2f1.h	2020-07-25 04:44:17.165964700 +0200
-+++ 5.3.3f1.h	2020-07-25 04:44:17.199470300 +0200
+--- 5.3.2f1.h
++++ 5.3.3f1.h
 @@ -2,6 +2,7 @@ typedef void (*methodPointerType)();
  typedef int32_t il2cpp_array_size_t;
  typedef uint32_t Il2CppMethodSlot;
@@ -235,8 +235,8 @@
  } Il2CppClass_1;
  
  typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
---- 5.3.4f1.h	2020-07-25 04:44:17.232976100 +0200
-+++ 5.3.5f1.h	2020-07-25 04:44:17.267982400 +0200
+--- 5.3.4f1.h
++++ 5.3.5f1.h
 @@ -1,4 +1,106 @@
 -typedef void (*methodPointerType)();
 +typedef struct Il2CppClass Il2CppClass;
@@ -480,8 +480,8 @@
  } Il2CppCodeRegistration;
  typedef struct Il2CppMetadataRegistration
  {
---- 5.3.5f1.h	2020-07-25 04:44:17.267982400 +0200
-+++ 5.3.6f1.h	2020-07-25 04:44:17.304488800 +0200
+--- 5.3.5f1.h
++++ 5.3.6f1.h
 @@ -1,3 +1,6 @@
 +typedef uint32_t Il2CppMethodSlot;
 +const int ipv6AddressSize = 16;
@@ -682,8 +682,8 @@
  
  struct MonitorData;
  struct Il2CppObject {
---- 5.3.6f1.h	2020-07-25 04:44:17.304488800 +0200
-+++ 5.3.7f1.h	2020-07-25 04:44:17.339494700 +0200
+--- 5.3.6f1.h
++++ 5.3.7f1.h
 @@ -950,9 +950,9 @@ typedef struct Il2CppMetadataRegistratio
   int32_t methodSpecsCount;
   const Il2CppMethodSpec* methodSpecs;
@@ -696,8 +696,8 @@
   const size_t metadataUsagesCount;
   void** const* metadataUsages;
  } Il2CppMetadataRegistration;
---- 5.3.8f2.h	2020-07-25 04:44:17.374500900 +0200
-+++ 5.4.0f3.h	2020-07-25 04:44:17.409007300 +0200
+--- 5.3.8f2.h
++++ 5.4.0f3.h
 @@ -950,9 +950,9 @@ typedef struct Il2CppMetadataRegistratio
   int32_t methodSpecsCount;
   const Il2CppMethodSpec* methodSpecs;
@@ -710,8 +710,8 @@
   const size_t metadataUsagesCount;
   void** const* metadataUsages;
  } Il2CppMetadataRegistration;
---- 5.4.0f3.h	2020-07-25 04:44:17.409007300 +0200
-+++ 5.4.1f1.h	2020-07-25 04:44:17.442512600 +0200
+--- 5.4.0f3.h
++++ 5.4.1f1.h
 @@ -950,9 +950,9 @@ typedef struct Il2CppMetadataRegistratio
   int32_t methodSpecsCount;
   const Il2CppMethodSpec* methodSpecs;
@@ -724,8 +724,8 @@
   const size_t metadataUsagesCount;
   void** const* metadataUsages;
  } Il2CppMetadataRegistration;
---- 5.4.3f1.h	2020-07-25 04:44:17.511024800 +0200
-+++ 5.4.4f1.h	2020-07-25 04:44:17.545030300 +0200
+--- 5.4.3f1.h
++++ 5.4.4f1.h
 @@ -788,6 +788,7 @@ typedef struct Il2CppClass
   uint16_t interfaces_count;
   uint16_t interface_offsets_count;
@@ -742,8 +742,8 @@
      uint8_t rank;
      uint8_t minimumAlignment;
      uint8_t packingSize;
---- 5.4.6f3.h	2020-07-25 04:44:17.615042700 +0200
-+++ 5.5.0f3.h	2020-07-25 04:44:17.649048600 +0200
+--- 5.4.6f3.h
++++ 5.5.0f3.h
 @@ -409,6 +409,11 @@ typedef struct Il2CppCustomAttributeType
   int32_t start;
   int32_t count;
@@ -861,8 +861,8 @@
  } Il2CppCodeRegistration;
  typedef struct Il2CppMetadataRegistration
  {
---- 5.5.0f3.h	2020-07-25 04:44:17.649048600 +0200
-+++ 5.5.1f1.h	2020-07-25 04:44:17.683054700 +0200
+--- 5.5.0f3.h
++++ 5.5.1f1.h
 @@ -801,6 +801,7 @@ typedef struct Il2CppClass
   uint16_t interfaces_count;
   uint16_t interface_offsets_count;
@@ -879,8 +879,8 @@
      uint8_t rank;
      uint8_t minimumAlignment;
      uint8_t packingSize;
---- 5.5.2f1.h	2020-07-25 04:44:17.717060900 +0200
-+++ 5.5.3f1.h	2020-07-25 04:44:17.751566400 +0200
+--- 5.5.2f1.h
++++ 5.5.3f1.h
 @@ -84,7 +84,8 @@ typedef struct Il2CppStackFrameInfo
  {
   const MethodInfo *method;
@@ -921,8 +921,8 @@
   Il2CppImage *corlib;
   Il2CppClass *object_class;
   Il2CppClass *byte_class;
---- 5.5.6f1.h	2020-07-25 04:44:17.855084500 +0200
-+++ 5.6.0f3.h	2020-07-25 04:44:17.888590300 +0200
+--- 5.5.6f1.h
++++ 5.6.0f3.h
 @@ -84,8 +84,7 @@ typedef struct Il2CppStackFrameInfo
  {
      const MethodInfo *method;
@@ -1114,8 +1114,8 @@
  } Il2CppCodeRegistration;
  typedef struct Il2CppMetadataRegistration
  {
---- 5.6.0f3.h	2020-07-25 04:44:17.888590300 +0200
-+++ 5.6.1f1.h	2020-07-25 04:44:17.923096700 +0200
+--- 5.6.0f3.h
++++ 5.6.1f1.h
 @@ -84,7 +84,8 @@ typedef struct Il2CppStackFrameInfo
  {
   const MethodInfo *method;
@@ -1175,8 +1175,8 @@
  typedef struct Il2CppInteropData
  {
   Il2CppMethodPointer delegatePInvokeWrapperFunction;
---- 5.6.7f1.h	2020-07-25 04:44:18.130132300 +0200
-+++ 2017.1.0f3.h	2020-07-25 04:44:15.618695200 +0200
+--- 5.6.7f1.h
++++ 2017.1.0f3.h
 @@ -218,7 +218,8 @@ typedef enum Il2CppRGCTXDataType
      IL2CPP_RGCTX_DATA_INVALID,
      IL2CPP_RGCTX_DATA_TYPE,
@@ -1223,8 +1223,8 @@
      MethodIndex entryPointIndex;
      Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
      uint32_t token;
---- 2017.1.2f1.h	2020-07-25 04:44:15.689707600 +0200
-+++ 2017.1.3f1.h	2020-07-25 04:44:15.725713900 +0200
+--- 2017.1.2f1.h
++++ 2017.1.3f1.h
 @@ -952,6 +952,7 @@ typedef struct Il2CppDomain
  typedef struct Il2CppImage
  {
@@ -1233,8 +1233,8 @@
      AssemblyIndex assemblyIndex;
      TypeDefinitionIndex typeStart;
      uint32_t typeCount;
---- 2017.1.5f1.h	2020-07-25 04:44:15.794725900 +0200
-+++ 2017.2.0f3.h	2020-07-25 04:44:15.830732300 +0200
+--- 2017.1.5f1.h
++++ 2017.2.0f3.h
 @@ -108,7 +108,7 @@ typedef const Il2CppNativeChar* (*Il2Cpp
  typedef void (*Il2CppLogCallback)(const char*);
  typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
@@ -1252,8 +1252,8 @@
      AssemblyIndex assemblyIndex;
      TypeDefinitionIndex typeStart;
      uint32_t typeCount;
---- 2017.2.0f3.h	2020-07-25 04:44:15.830732300 +0200
-+++ 2017.2.1f1.h	2020-07-25 04:44:15.866238700 +0200
+--- 2017.2.0f3.h
++++ 2017.2.1f1.h
 @@ -952,6 +952,7 @@ typedef struct Il2CppDomain
  typedef struct Il2CppImage
  {
@@ -1262,8 +1262,8 @@
      AssemblyIndex assemblyIndex;
      TypeDefinitionIndex typeStart;
      uint32_t typeCount;
---- 2017.2.5f1.h	2020-07-25 04:44:16.010263400 +0200
-+++ 2017.3.0f3.h	2020-07-25 04:44:16.046270300 +0200
+--- 2017.2.5f1.h
++++ 2017.3.0f3.h
 @@ -42,8 +42,14 @@ typedef enum Il2CppProfileFlags
      IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
      IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
@@ -1302,16 +1302,16 @@
  typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
  typedef void (*Il2CppLogCallback)(const char*);
  typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
---- 2017.3.1f1.h	2020-07-25 04:44:16.083276700 +0200
-+++ 2017.4.1f1.h	2020-07-25 04:44:16.483346400 +0200
+--- 2017.3.1f1.h
++++ 2017.4.1f1.h
 @@ -1,4 +1,5 @@
  typedef uint32_t Il2CppMethodSlot;
 +const uint32_t kInvalidIl2CppMethodSlot = 65535;
  const int ipv6AddressSize = 16;
  typedef int32_t il2cpp_hresult_t;
  typedef struct Il2CppClass Il2CppClass;
---- 2017.4.40f1.h	2020-07-25 04:44:18.413182100 +0200
-+++ 2018.1.0f2.h	2020-07-25 04:44:18.666225700 +0200
+--- 2017.4.40f1.h
++++ 2018.1.0f2.h
 @@ -1,7 +1,3 @@
 -typedef uint32_t Il2CppMethodSlot;
 -const uint32_t kInvalidIl2CppMethodSlot = 65535;
@@ -1645,8 +1645,8 @@
  } Il2CppRuntimeStats;
  extern Il2CppRuntimeStats il2cpp_runtime_stats;
  typedef struct Il2CppPerfCounters
---- 2018.1.9f2.h	2020-07-25 04:44:19.004784500 +0200
-+++ 2018.2.0f2.h	2020-07-25 04:44:19.043291700 +0200
+--- 2018.1.9f2.h
++++ 2018.2.0f2.h
 @@ -668,6 +668,7 @@ typedef struct Il2CppDefaults
      Il2CppClass* windows_foundation_uri_class;
      Il2CppClass* windows_foundation_iuri_runtime_class_class;
@@ -1786,8 +1786,8 @@
  } Il2CppClass_1;
  
  typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
---- 2018.2.11f1.h	2020-07-25 04:44:19.118304200 +0200
-+++ 2018.2.12f1.h	2020-07-25 04:44:19.156310900 +0200
+--- 2018.2.11f1.h
++++ 2018.2.12f1.h
 @@ -565,7 +565,8 @@ typedef enum Il2CppCallConvention
  typedef enum Il2CppCharSet
  {
@@ -1798,8 +1798,8 @@
  } Il2CppCharSet;
  typedef struct Il2CppClass Il2CppClass;
  typedef struct Il2CppGuid Il2CppGuid;
---- 2018.2.15f1.h	2020-07-25 04:44:19.268830500 +0200
-+++ 2018.2.16f1.h	2020-07-25 04:44:19.308337500 +0200
+--- 2018.2.15f1.h
++++ 2018.2.16f1.h
 @@ -664,6 +664,7 @@ typedef struct Il2CppDefaults
      Il2CppClass *missing_class;
      Il2CppClass *value_type_class;
@@ -1808,8 +1808,8 @@
      Il2CppClass* ikey_value_pair_class;
      Il2CppClass* key_value_pair_class;
      Il2CppClass* windows_foundation_uri_class;
---- 2018.2.21f1.h	2020-07-25 04:44:19.533876800 +0200
-+++ 2018.3.0f2.h	2020-07-25 04:44:19.879936800 +0200
+--- 2018.2.21f1.h
++++ 2018.3.0f2.h
 @@ -18,6 +18,7 @@ typedef struct Il2CppString Il2CppString
  typedef struct Il2CppThread Il2CppThread;
  typedef struct Il2CppAsyncResult Il2CppAsyncResult;
@@ -2037,8 +2037,8 @@
      int32_t referencedAssemblyStart;
      int32_t referencedAssemblyCount;
      Il2CppAssemblyName aname;
---- 2018.3.7f1.h	2020-07-25 04:44:20.338016700 +0200
-+++ 2018.3.8f1.h	2020-07-25 04:44:20.375523200 +0200
+--- 2018.3.7f1.h
++++ 2018.3.8f1.h
 @@ -903,6 +903,7 @@ typedef struct Il2CppClass
      uint8_t genericRecursionDepth;
      uint8_t rank;
@@ -2055,8 +2055,8 @@
      uint8_t packingSize;
      uint8_t initialized_and_no_error : 1;
      uint8_t valuetype : 1;
---- 2018.4.17f1.h	2020-07-25 04:44:20.752088600 +0200
-+++ 2018.4.18f1.h	2020-07-25 04:44:20.789095000 +0200
+--- 2018.4.17f1.h
++++ 2018.4.18f1.h
 @@ -1065,6 +1065,11 @@ typedef struct Il2CppCodeGenOptions
  {
      uint8_t enablePrimitiveValueTypeGenericSharing;
@@ -2078,8 +2078,8 @@
  } Il2CppCodeRegistration;
  typedef struct Il2CppMetadataRegistration
  {
---- 2018.4.25f1.h	2020-07-25 04:44:21.092147900 +0200
-+++ 2019.1.0f2.h	2020-07-25 04:44:21.435707500 +0200
+--- 2018.4.25f1.h
++++ 2019.1.0f2.h
 @@ -110,8 +110,8 @@ typedef struct Il2CppManagedMemorySnapsh
  typedef void (*Il2CppMethodPointer)();
  typedef uintptr_t il2cpp_array_size_t;
@@ -2598,8 +2598,8 @@
  } Il2CppCodeRegistration;
  typedef struct Il2CppMetadataRegistration
  {
---- 2019.1.14f1.h	2020-07-25 04:44:21.636742400 +0200
-+++ 2019.2.0f1.h	2020-07-25 04:44:22.033312100 +0200
+--- 2019.1.14f1.h
++++ 2019.2.0f1.h
 @@ -109,6 +109,7 @@ typedef void (*Il2CppLogCallback)(const
  typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
  typedef void (*Il2CppMethodPointer)();
@@ -2646,8 +2646,8 @@
  typedef struct Il2CppPerfCounters
  {
      uint32_t jit_methods;
---- 2019.2.21f1.h	2020-07-25 04:44:22.558403000 +0200
-+++ 2019.3.0f6.h	2020-07-25 04:44:22.918465800 +0200
+--- 2019.2.21f1.h
++++ 2019.3.0f6.h
 @@ -82,6 +82,13 @@ typedef struct Il2CppStackFrameInfo
  {
      const MethodInfo *method;
@@ -2813,8 +2813,8 @@
      const uint32_t rgctxRangesCount;
      const Il2CppTokenRangePair* rgctxRanges;
      const uint32_t rgctxsCount;
---- 2019.3.6f1.h	2020-07-25 04:44:23.403550400 +0200
-+++ 2019.3.7f1.h	2020-07-25 04:44:23.443557400 +0200
+--- 2019.3.6f1.h
++++ 2019.3.7f1.h
 @@ -1345,6 +1345,11 @@ typedef struct Il2CppTokenIndexMethodTup
      void** method;
      uint32_t genericMethodIndex;
@@ -2836,8 +2836,8 @@
      uint32_t codeGenModulesCount;
      const Il2CppCodeGenModule** codeGenModules;
  } Il2CppCodeRegistration;
---- 2019.4.5f1.h	2020-07-25 04:44:23.768613500 +0200
-+++ 2020.1.0f1.h	2020-07-25 04:44:23.808120400 +0200
+--- 2019.4.6f1.h
++++ 2020.1.0f1.h
 @@ -81,6 +81,7 @@ typedef enum
  typedef struct Il2CppStackFrameInfo
  {

--- a/headers/diffs.sh
+++ b/headers/diffs.sh
@@ -2,5 +2,5 @@ vers=($(ls *.h | sort -t. -k1,1n -k2,2n -k3,3n))
 rm -f diffs.diff
 for ((i=0; i<${#vers[@]}-1; i++)); do
     echo ${vers[i]} .. ${vers[i+1]}
-    diff -purwB ${vers[i]} ${vers[i+1]} >> diffs.diff
+    diff -purwB --label=${vers[i]} --label=${vers[i+1]} ${vers[i]} ${vers[i+1]} >> diffs.diff
 done


### PR DESCRIPTION
Uses the --label feature of `diff` to suppress the timestamp from ---/+++ change lines and only include the filename.
