### PR TITLE
Add Last Versions

### DIFF
--- a/api/2019.4.40f1.h
+++ b/api/2019.4.40f1.h
@@ -1,0 +1,306 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_calculation_begin, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_WorldChangedCallback onWorldStarted, il2cpp_WorldChangedCallback onWorldStopped));
+DO_API(void, il2cpp_unity_liveness_calculation_end, (void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/2020.3.35f1.h
+++ b/api/2020.3.35f1.h
@@ -1,0 +1,309 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_start_incremental_collection , ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(void, il2cpp_gc_set_mode, (Il2CppGCMode mode));
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_calculation_begin, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_WorldChangedCallback onWorldStarted, il2cpp_WorldChangedCallback onWorldStopped));
+DO_API(void, il2cpp_unity_liveness_calculation_end, (void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/2020.3.36f1.h
+++ b/api/2020.3.36f1.h
@@ -1,0 +1,309 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_start_incremental_collection , ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(void, il2cpp_gc_set_mode, (Il2CppGCMode mode));
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_calculation_begin, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_WorldChangedCallback onWorldStarted, il2cpp_WorldChangedCallback onWorldStopped));
+DO_API(void, il2cpp_unity_liveness_calculation_end, (void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/2020.3.37f1.h
+++ b/api/2020.3.37f1.h
@@ -1,0 +1,309 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_start_incremental_collection , ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(void, il2cpp_gc_set_mode, (Il2CppGCMode mode));
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_calculation_begin, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_WorldChangedCallback onWorldStarted, il2cpp_WorldChangedCallback onWorldStopped));
+DO_API(void, il2cpp_unity_liveness_calculation_end, (void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/2020.3.38f1.h
+++ b/api/2020.3.38f1.h
@@ -1,0 +1,309 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_start_incremental_collection , ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(void, il2cpp_gc_set_mode, (Il2CppGCMode mode));
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_calculation_begin, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_WorldChangedCallback onWorldStarted, il2cpp_WorldChangedCallback onWorldStopped));
+DO_API(void, il2cpp_unity_liveness_calculation_end, (void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/2020.3.39f1.h
+++ b/api/2020.3.39f1.h
@@ -1,0 +1,309 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_start_incremental_collection , ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(void, il2cpp_gc_set_mode, (Il2CppGCMode mode));
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_calculation_begin, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_WorldChangedCallback onWorldStarted, il2cpp_WorldChangedCallback onWorldStopped));
+DO_API(void, il2cpp_unity_liveness_calculation_end, (void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/2021.3.10f1.h
+++ b/api/2021.3.10f1.h
@@ -1,0 +1,312 @@
+#ifndef DO_API_NO_RETURN
+#define DO_API_NO_RETURN(r, n, p) DO_API(r,n,p)
+#endif
+
+DO_API(int, il2cpp_init, (const char* domain_name));
+DO_API(int, il2cpp_init_utf16, (const Il2CppChar * domain_name));
+DO_API(void, il2cpp_shutdown, ());
+DO_API(void, il2cpp_set_config_dir, (const char *config_path));
+DO_API(void, il2cpp_set_data_dir, (const char *data_path));
+DO_API(void, il2cpp_set_temp_dir, (const char *temp_path));
+DO_API(void, il2cpp_set_commandline_arguments, (int argc, const char* const argv[], const char* basedir));
+DO_API(void, il2cpp_set_commandline_arguments_utf16, (int argc, const Il2CppChar * const argv[], const char* basedir));
+DO_API(void, il2cpp_set_config_utf16, (const Il2CppChar * executablePath));
+DO_API(void, il2cpp_set_config, (const char* executablePath));
+
+DO_API(void, il2cpp_set_memory_callbacks, (Il2CppMemoryCallbacks * callbacks));
+DO_API(const Il2CppImage*, il2cpp_get_corlib, ());
+DO_API(void, il2cpp_add_internal_call, (const char* name, Il2CppMethodPointer method));
+DO_API(Il2CppMethodPointer, il2cpp_resolve_icall, (const char* name));
+
+DO_API(void*, il2cpp_alloc, (size_t size));
+DO_API(void, il2cpp_free, (void* ptr));
+
+// array
+DO_API(Il2CppClass*, il2cpp_array_class_get, (Il2CppClass * element_class, uint32_t rank));
+DO_API(uint32_t, il2cpp_array_length, (Il2CppArray * array));
+DO_API(uint32_t, il2cpp_array_get_byte_length, (Il2CppArray * array));
+DO_API(Il2CppArray*, il2cpp_array_new, (Il2CppClass * elementTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_specific, (Il2CppClass * arrayTypeInfo, il2cpp_array_size_t length));
+DO_API(Il2CppArray*, il2cpp_array_new_full, (Il2CppClass * array_class, il2cpp_array_size_t * lengths, il2cpp_array_size_t * lower_bounds));
+DO_API(Il2CppClass*, il2cpp_bounded_array_class_get, (Il2CppClass * element_class, uint32_t rank, bool bounded));
+DO_API(int, il2cpp_array_element_size, (const Il2CppClass * array_class));
+
+// assembly
+DO_API(const Il2CppImage*, il2cpp_assembly_get_image, (const Il2CppAssembly * assembly));
+
+// class
+DO_API(void, il2cpp_class_for_each, (void(*klassReportFunc)(Il2CppClass* klass, void* userData), void* userData));
+DO_API(const Il2CppType*, il2cpp_class_enum_basetype, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_generic, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_inflated, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_assignable_from, (Il2CppClass * klass, Il2CppClass * oklass));
+DO_API(bool, il2cpp_class_is_subclass_of, (Il2CppClass * klass, Il2CppClass * klassc, bool check_interfaces));
+DO_API(bool, il2cpp_class_has_parent, (Il2CppClass * klass, Il2CppClass * klassc));
+DO_API(Il2CppClass*, il2cpp_class_from_il2cpp_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_class_from_name, (const Il2CppImage * image, const char* namespaze, const char *name));
+DO_API(Il2CppClass*, il2cpp_class_from_system_type, (Il2CppReflectionType * type));
+DO_API(Il2CppClass*, il2cpp_class_get_element_class, (Il2CppClass * klass));
+DO_API(const EventInfo*, il2cpp_class_get_events, (Il2CppClass * klass, void* *iter));
+DO_API(FieldInfo*, il2cpp_class_get_fields, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_nested_types, (Il2CppClass * klass, void* *iter));
+DO_API(Il2CppClass*, il2cpp_class_get_interfaces, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_properties, (Il2CppClass * klass, void* *iter));
+DO_API(const PropertyInfo*, il2cpp_class_get_property_from_name, (Il2CppClass * klass, const char *name));
+DO_API(FieldInfo*, il2cpp_class_get_field_from_name, (Il2CppClass * klass, const char *name));
+DO_API(const MethodInfo*, il2cpp_class_get_methods, (Il2CppClass * klass, void* *iter));
+DO_API(const MethodInfo*, il2cpp_class_get_method_from_name, (Il2CppClass * klass, const char* name, int argsCount));
+DO_API(const char*, il2cpp_class_get_name, (Il2CppClass * klass));
+DO_API(void, il2cpp_type_get_name_chunked, (const Il2CppType * type, void(*chunkReportFunc)(void* data, void* userData), void* userData));
+DO_API(const char*, il2cpp_class_get_namespace, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_parent, (Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_get_declaring_type, (Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_instance_size, (Il2CppClass * klass));
+DO_API(size_t, il2cpp_class_num_fields, (const Il2CppClass * enumKlass));
+DO_API(bool, il2cpp_class_is_valuetype, (const Il2CppClass * klass));
+DO_API(int32_t, il2cpp_class_value_size, (Il2CppClass * klass, uint32_t * align));
+DO_API(bool, il2cpp_class_is_blittable, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_flags, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_abstract, (const Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_interface, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_array_element_size, (const Il2CppClass * klass));
+DO_API(Il2CppClass*, il2cpp_class_from_type, (const Il2CppType * type));
+DO_API(const Il2CppType*, il2cpp_class_get_type, (Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_type_token, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_has_attribute, (Il2CppClass * klass, Il2CppClass * attr_class));
+DO_API(bool, il2cpp_class_has_references, (Il2CppClass * klass));
+DO_API(bool, il2cpp_class_is_enum, (const Il2CppClass * klass));
+DO_API(const Il2CppImage*, il2cpp_class_get_image, (Il2CppClass * klass));
+DO_API(const char*, il2cpp_class_get_assemblyname, (const Il2CppClass * klass));
+DO_API(int, il2cpp_class_get_rank, (const Il2CppClass * klass));
+DO_API(uint32_t, il2cpp_class_get_data_size, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_class_get_static_field_data, (const Il2CppClass * klass));
+
+// testing only
+DO_API(size_t, il2cpp_class_get_bitmap_size, (const Il2CppClass * klass));
+DO_API(void, il2cpp_class_get_bitmap, (Il2CppClass * klass, size_t * bitmap));
+
+// stats
+DO_API(bool, il2cpp_stats_dump_to_file, (const char *path));
+DO_API(uint64_t, il2cpp_stats_get_value, (Il2CppStat stat));
+
+// domain
+DO_API(Il2CppDomain*, il2cpp_domain_get, ());
+DO_API(const Il2CppAssembly*, il2cpp_domain_assembly_open, (Il2CppDomain * domain, const char* name));
+DO_API(const Il2CppAssembly**, il2cpp_domain_get_assemblies, (const Il2CppDomain * domain, size_t * size));
+
+// exception
+DO_API_NO_RETURN(void, il2cpp_raise_exception, (Il2CppException*));
+DO_API(Il2CppException*, il2cpp_exception_from_name_msg, (const Il2CppImage * image, const char *name_space, const char *name, const char *msg));
+DO_API(Il2CppException*, il2cpp_get_exception_argument_null, (const char *arg));
+DO_API(void, il2cpp_format_exception, (const Il2CppException * ex, char* message, int message_size));
+DO_API(void, il2cpp_format_stack_trace, (const Il2CppException * ex, char* output, int output_size));
+DO_API(void, il2cpp_unhandled_exception, (Il2CppException*));
+DO_API(void, il2cpp_native_stack_trace, (const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char** imageUUID, char** imageName));
+
+// field
+DO_API(int, il2cpp_field_get_flags, (FieldInfo * field));
+DO_API(const char*, il2cpp_field_get_name, (FieldInfo * field));
+DO_API(Il2CppClass*, il2cpp_field_get_parent, (FieldInfo * field));
+DO_API(size_t, il2cpp_field_get_offset, (FieldInfo * field));
+DO_API(const Il2CppType*, il2cpp_field_get_type, (FieldInfo * field));
+DO_API(void, il2cpp_field_get_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(Il2CppObject*, il2cpp_field_get_value_object, (FieldInfo * field, Il2CppObject * obj));
+DO_API(bool, il2cpp_field_has_attribute, (FieldInfo * field, Il2CppClass * attr_class));
+DO_API(void, il2cpp_field_set_value, (Il2CppObject * obj, FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_get_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_static_set_value, (FieldInfo * field, void *value));
+DO_API(void, il2cpp_field_set_value_object, (Il2CppObject * instance, FieldInfo * field, Il2CppObject * value));
+DO_API(bool, il2cpp_field_is_literal, (FieldInfo * field));
+// gc
+DO_API(void, il2cpp_gc_collect, (int maxGenerations));
+DO_API(int32_t, il2cpp_gc_collect_a_little, ());
+DO_API(void, il2cpp_gc_start_incremental_collection , ());
+DO_API(void, il2cpp_gc_disable, ());
+DO_API(void, il2cpp_gc_enable, ());
+DO_API(bool, il2cpp_gc_is_disabled, ());
+DO_API(void, il2cpp_gc_set_mode, (Il2CppGCMode mode));
+DO_API(int64_t, il2cpp_gc_get_max_time_slice_ns, ());
+DO_API(void, il2cpp_gc_set_max_time_slice_ns, (int64_t maxTimeSlice));
+DO_API(bool, il2cpp_gc_is_incremental, ());
+DO_API(int64_t, il2cpp_gc_get_used_size, ());
+DO_API(int64_t, il2cpp_gc_get_heap_size, ());
+DO_API(void, il2cpp_gc_wbarrier_set_field, (Il2CppObject * obj, void **targetAddress, void *object));
+DO_API(bool, il2cpp_gc_has_strict_wbarriers, ());
+DO_API(void, il2cpp_gc_set_external_allocation_tracker, (void(*func)(void*, size_t, int)));
+DO_API(void, il2cpp_gc_set_external_wbarrier_tracker, (void(*func)(void**)));
+DO_API(void, il2cpp_gc_foreach_heap, (void(*func)(void* data, void* userData), void* userData));
+DO_API(void, il2cpp_stop_gc_world, ());
+DO_API(void, il2cpp_start_gc_world, ());
+DO_API(void*, il2cpp_gc_alloc_fixed, (size_t size));
+DO_API(void, il2cpp_gc_free_fixed, (void* address));
+// gchandle
+DO_API(uint32_t, il2cpp_gchandle_new, (Il2CppObject * obj, bool pinned));
+DO_API(uint32_t, il2cpp_gchandle_new_weakref, (Il2CppObject * obj, bool track_resurrection));
+DO_API(Il2CppObject*, il2cpp_gchandle_get_target , (uint32_t gchandle));
+DO_API(void, il2cpp_gchandle_free, (uint32_t gchandle));
+DO_API(void , il2cpp_gchandle_foreach_get_target, (void(*func)(void* data, void* userData), void* userData));
+
+// vm runtime info
+DO_API(uint32_t, il2cpp_object_header_size, ());
+DO_API(uint32_t, il2cpp_array_object_header_size, ());
+DO_API(uint32_t, il2cpp_offset_of_array_length_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_offset_of_array_bounds_in_array_object_header, ());
+DO_API(uint32_t, il2cpp_allocation_granularity, ());
+
+// liveness
+DO_API(void*, il2cpp_unity_liveness_allocate_struct, (Il2CppClass * filter, int max_object_count, il2cpp_register_object_callback callback, void* userdata, il2cpp_liveness_reallocate_callback reallocate));
+DO_API(void, il2cpp_unity_liveness_calculation_from_root, (Il2CppObject * root, void* state));
+DO_API(void, il2cpp_unity_liveness_calculation_from_statics, (void* state));
+DO_API(void, il2cpp_unity_liveness_finalize, (void* state));
+DO_API(void, il2cpp_unity_liveness_free_struct, (void* state));
+
+// method
+DO_API(const Il2CppType*, il2cpp_method_get_return_type, (const MethodInfo * method));
+DO_API(Il2CppClass*, il2cpp_method_get_declaring_type, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_name, (const MethodInfo * method));
+DO_API(const MethodInfo*, il2cpp_method_get_from_reflection, (const Il2CppReflectionMethod * method));
+DO_API(Il2CppReflectionMethod*, il2cpp_method_get_object, (const MethodInfo * method, Il2CppClass * refclass));
+DO_API(bool, il2cpp_method_is_generic, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_inflated, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_is_instance, (const MethodInfo * method));
+DO_API(uint32_t, il2cpp_method_get_param_count, (const MethodInfo * method));
+DO_API(const Il2CppType*, il2cpp_method_get_param, (const MethodInfo * method, uint32_t index));
+DO_API(Il2CppClass*, il2cpp_method_get_class, (const MethodInfo * method));
+DO_API(bool, il2cpp_method_has_attribute, (const MethodInfo * method, Il2CppClass * attr_class));
+DO_API(uint32_t, il2cpp_method_get_flags, (const MethodInfo * method, uint32_t * iflags));
+DO_API(uint32_t, il2cpp_method_get_token, (const MethodInfo * method));
+DO_API(const char*, il2cpp_method_get_param_name, (const MethodInfo * method, uint32_t index));
+
+// profiler
+#if IL2CPP_ENABLE_PROFILER
+
+DO_API(void, il2cpp_profiler_install, (Il2CppProfiler * prof, Il2CppProfileFunc shutdown_callback));
+DO_API(void, il2cpp_profiler_set_events, (Il2CppProfileFlags events));
+DO_API(void, il2cpp_profiler_install_enter_leave, (Il2CppProfileMethodFunc enter, Il2CppProfileMethodFunc fleave));
+DO_API(void, il2cpp_profiler_install_allocation, (Il2CppProfileAllocFunc callback));
+DO_API(void, il2cpp_profiler_install_gc, (Il2CppProfileGCFunc callback, Il2CppProfileGCResizeFunc heap_resize_callback));
+DO_API(void, il2cpp_profiler_install_fileio, (Il2CppProfileFileIOFunc callback));
+DO_API(void, il2cpp_profiler_install_thread, (Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end));
+
+#endif
+
+// property
+DO_API(uint32_t, il2cpp_property_get_flags, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_get_method, (PropertyInfo * prop));
+DO_API(const MethodInfo*, il2cpp_property_get_set_method, (PropertyInfo * prop));
+DO_API(const char*, il2cpp_property_get_name, (PropertyInfo * prop));
+DO_API(Il2CppClass*, il2cpp_property_get_parent, (PropertyInfo * prop));
+
+// object
+DO_API(Il2CppClass*, il2cpp_object_get_class, (Il2CppObject * obj));
+DO_API(uint32_t, il2cpp_object_get_size, (Il2CppObject * obj));
+DO_API(const MethodInfo*, il2cpp_object_get_virtual_method, (Il2CppObject * obj, const MethodInfo * method));
+DO_API(Il2CppObject*, il2cpp_object_new, (const Il2CppClass * klass));
+DO_API(void*, il2cpp_object_unbox, (Il2CppObject * obj));
+
+DO_API(Il2CppObject*, il2cpp_value_box, (Il2CppClass * klass, void* data));
+
+// monitor
+DO_API(void, il2cpp_monitor_enter, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_enter, (Il2CppObject * obj, uint32_t timeout));
+DO_API(void, il2cpp_monitor_exit, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_pulse_all, (Il2CppObject * obj));
+DO_API(void, il2cpp_monitor_wait, (Il2CppObject * obj));
+DO_API(bool, il2cpp_monitor_try_wait, (Il2CppObject * obj, uint32_t timeout));
+
+// runtime
+DO_API(Il2CppObject*, il2cpp_runtime_invoke, (const MethodInfo * method, void *obj, void **params, Il2CppException **exc));
+DO_API(Il2CppObject*, il2cpp_runtime_invoke_convert_args, (const MethodInfo * method, void *obj, Il2CppObject **params, int paramCount, Il2CppException **exc));
+DO_API(void, il2cpp_runtime_class_init, (Il2CppClass * klass));
+DO_API(void, il2cpp_runtime_object_init, (Il2CppObject * obj));
+
+DO_API(void, il2cpp_runtime_object_init_exception, (Il2CppObject * obj, Il2CppException** exc));
+
+DO_API(void, il2cpp_runtime_unhandled_exception_policy_set, (Il2CppRuntimeUnhandledExceptionPolicy value));
+
+// string
+DO_API(int32_t, il2cpp_string_length, (Il2CppString * str));
+DO_API(Il2CppChar*, il2cpp_string_chars, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_new, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_new_len, (const char* str, uint32_t length));
+DO_API(Il2CppString*, il2cpp_string_new_utf16, (const Il2CppChar * text, int32_t len));
+DO_API(Il2CppString*, il2cpp_string_new_wrapper, (const char* str));
+DO_API(Il2CppString*, il2cpp_string_intern, (Il2CppString * str));
+DO_API(Il2CppString*, il2cpp_string_is_interned, (Il2CppString * str));
+
+// thread
+DO_API(Il2CppThread*, il2cpp_thread_current, ());
+DO_API(Il2CppThread*, il2cpp_thread_attach, (Il2CppDomain * domain));
+DO_API(void, il2cpp_thread_detach, (Il2CppThread * thread));
+
+DO_API(Il2CppThread**, il2cpp_thread_get_all_attached_threads, (size_t * size));
+DO_API(bool, il2cpp_is_vm_thread, (Il2CppThread * thread));
+
+// stacktrace
+DO_API(void, il2cpp_current_thread_walk_frame_stack, (Il2CppFrameWalkFunc func, void* user_data));
+DO_API(void, il2cpp_thread_walk_frame_stack, (Il2CppThread * thread, Il2CppFrameWalkFunc func, void* user_data));
+DO_API(bool, il2cpp_current_thread_get_top_frame, (Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_top_frame, (Il2CppThread * thread, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_current_thread_get_frame_at, (int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(bool, il2cpp_thread_get_frame_at, (Il2CppThread * thread, int32_t offset, Il2CppStackFrameInfo * frame));
+DO_API(int32_t, il2cpp_current_thread_get_stack_depth, ());
+DO_API(int32_t, il2cpp_thread_get_stack_depth, (Il2CppThread * thread));
+DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
+
+// type
+DO_API(Il2CppObject*, il2cpp_type_get_object, (const Il2CppType * type));
+DO_API(int, il2cpp_type_get_type, (const Il2CppType * type));
+DO_API(Il2CppClass*, il2cpp_type_get_class_or_element_class, (const Il2CppType * type));
+DO_API(char*, il2cpp_type_get_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_byref, (const Il2CppType * type));
+DO_API(uint32_t, il2cpp_type_get_attrs, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_equals, (const Il2CppType * type, const Il2CppType * otherType));
+DO_API(char*, il2cpp_type_get_assembly_qualified_name, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_static, (const Il2CppType * type));
+DO_API(bool, il2cpp_type_is_pointer_type, (const Il2CppType * type));
+
+// image
+DO_API(const Il2CppAssembly*, il2cpp_image_get_assembly, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_name, (const Il2CppImage * image));
+DO_API(const char*, il2cpp_image_get_filename, (const Il2CppImage * image));
+DO_API(const MethodInfo*, il2cpp_image_get_entry_point, (const Il2CppImage * image));
+
+DO_API(size_t, il2cpp_image_get_class_count, (const Il2CppImage * image));
+DO_API(const Il2CppClass*, il2cpp_image_get_class, (const Il2CppImage * image, size_t index));
+
+// Memory information
+DO_API(Il2CppManagedMemorySnapshot*, il2cpp_capture_memory_snapshot, ());
+DO_API(void, il2cpp_free_captured_memory_snapshot, (Il2CppManagedMemorySnapshot * snapshot));
+
+DO_API(void, il2cpp_set_find_plugin_callback, (Il2CppSetFindPlugInCallback method));
+
+// Logging
+DO_API(void, il2cpp_register_log_callback, (Il2CppLogCallback method));
+
+// Debugger
+DO_API(void, il2cpp_debugger_set_agent_options, (const char* options));
+DO_API(bool, il2cpp_is_debugger_attached, ());
+DO_API(void, il2cpp_register_debugger_agent_transport, (Il2CppDebuggerTransport * debuggerTransport));
+
+// Debug metadata
+DO_API(bool, il2cpp_debug_get_method_info, (const MethodInfo*, Il2CppMethodDebugInfo * methodDebugInfo));
+
+// TLS module
+DO_API(void, il2cpp_unity_install_unitytls_interface, (const void* unitytlsInterfaceStruct));
+
+// custom attributes
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_class, (Il2CppClass * klass));
+DO_API(Il2CppCustomAttrInfo*, il2cpp_custom_attrs_from_method, (const MethodInfo * method));
+
+DO_API(Il2CppObject*, il2cpp_custom_attrs_get_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(bool, il2cpp_custom_attrs_has_attr, (Il2CppCustomAttrInfo * ainfo, Il2CppClass * attr_klass));
+DO_API(Il2CppArray*,  il2cpp_custom_attrs_construct, (Il2CppCustomAttrInfo * cinfo));
+
+DO_API(void, il2cpp_custom_attrs_free, (Il2CppCustomAttrInfo * ainfo));
+
+// Il2CppClass user data for GetComponent optimization
+DO_API(void, il2cpp_class_set_userdata, (Il2CppClass * klass, void* userdata));
+DO_API(int, il2cpp_class_get_userdata_offset, ());
+
+DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));

--- a/api/diffs.diff
+++ b/api/diffs.diff
@@ -379,7 +379,7 @@
 @@ -304,0 +305,2 @@
 +
 +DO_API(void, il2cpp_set_default_thread_affinity, (int64_t affinity_mask));
---- 2019.4.39f1.h
+--- 2019.4.40f1.h
 +++ 2020.1.0a3.h
 @@ -249 +248,0 @@
 -DO_API(void, il2cpp_override_stack_backtrace, (Il2CppBacktraceFunc stackBacktraceFunc));
@@ -424,7 +424,7 @@
 @@ -139,0 +140,2 @@
 +DO_API(void*, il2cpp_gc_alloc_fixed, (size_t size));
 +DO_API(void, il2cpp_gc_free_fixed, (void* address));
---- 2021.3.2f1.h
+--- 2021.3.10f1.h
 +++ 2022.1.0a7.h
 @@ -140,2 +139,0 @@
 -DO_API(void*, il2cpp_gc_alloc_fixed, (size_t size));

--- a/headers/2019.4.40f1.h
+++ b/headers/2019.4.40f1.h
@@ -1,0 +1,2289 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppTypeDefinitionMetadata Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+        Il2CppMethodPointer nativeFunction;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject *type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/headers/2020.3.35f1.h
+++ b/headers/2020.3.35f1.h
@@ -1,0 +1,2365 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_GC_MODE_DISABLED = 0,
+    IL2CPP_GC_MODE_ENABLED = 1,
+    IL2CPP_GC_MODE_MANUAL = 2
+} Il2CppGCMode;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+    uintptr_t raw_ip;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint16_t Il2CppMethodSlot;
+static const uint16_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+typedef int32_t TypeFieldIndex;
+typedef int32_t TypeMethodIndex;
+typedef int32_t MethodParameterIndex;
+typedef int32_t TypePropertyIndex;
+typedef int32_t TypeEventIndex;
+typedef int32_t TypeInterfaceIndex;
+typedef int32_t TypeNestedTypeIndex;
+typedef int32_t TypeInterfaceOffsetIndex;
+typedef int32_t GenericContainerParameterIndex;
+typedef int32_t AssemblyTypeIndex;
+typedef int32_t AssemblyExportedTypeIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex __methodIndex;
+    TypeIndex __typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static inline uint32_t GetTokenType(uint32_t token)
+{
+    return token & 0xFF000000;
+}
+static inline uint32_t GetTokenRowId(uint32_t token)
+{
+    return token & 0x00FFFFFF;
+}
+typedef const struct ___Il2CppMetadataImageHandle* Il2CppMetadataImageHandle;
+typedef const struct ___Il2CppMetadataCustomAttributeHandle* Il2CppMetadataCustomAttributeHandle;
+typedef const struct ___Il2CppMetadataTypeHandle* Il2CppMetadataTypeHandle;
+typedef const struct ___Il2CppMetadataMethodHandle* Il2CppMetadataMethodDefinitionHandle;
+typedef const struct ___Il2CppMetadataGenericContainerHandle* Il2CppMetadataGenericContainerHandle;
+typedef const struct ___Il2CppMetadataGenericParameterHandle* Il2CppMetadataGenericParameterHandle;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppMetadataRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppMetadataRange;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralSize;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataSize;
+    int32_t stringOffset;
+    int32_t stringSize;
+    int32_t eventsOffset;
+    int32_t eventsSize;
+    int32_t propertiesOffset;
+    int32_t propertiesSize;
+    int32_t methodsOffset;
+    int32_t methodsSize;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesSize;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesSize;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataSize;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesSize;
+    int32_t parametersOffset;
+    int32_t parametersSize;
+    int32_t fieldsOffset;
+    int32_t fieldsSize;
+    int32_t genericParametersOffset;
+    int32_t genericParametersSize;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsSize;
+    int32_t genericContainersOffset;
+    int32_t genericContainersSize;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesSize;
+    int32_t interfacesOffset;
+    int32_t interfacesSize;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsSize;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsSize;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsSize;
+    int32_t imagesOffset;
+    int32_t imagesSize;
+    int32_t assembliesOffset;
+    int32_t assembliesSize;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsSize;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesSize;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoSize;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesSize;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesSize;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesSize;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t windowsRuntimeStringsOffset;
+    int32_t windowsRuntimeStringsSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsSize;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericClass
+{
+    const Il2CppType* type;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex __klassIndex;
+        Il2CppMetadataTypeHandle typeHandle;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex __genericParameterIndex;
+        Il2CppMetadataGenericParameterHandle genericParameterHandle;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppMetadataFieldInfo
+{
+    const Il2CppType* type;
+    const char* name;
+    uint32_t token;
+} Il2CppMetadataFieldInfo;
+typedef struct Il2CppMetadataMethodInfo
+{
+    Il2CppMetadataMethodDefinitionHandle handle;
+    const char* name;
+    const Il2CppType* return_type;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMetadataMethodInfo;
+typedef struct Il2CppMetadataParameterInfo
+{
+    const char* name;
+    uint32_t token;
+    const Il2CppType* type;
+} Il2CppMetadataParameterInfo;
+typedef struct Il2CppMetadataPropertyInfo
+{
+    const char* name;
+    const MethodInfo* get;
+    const MethodInfo* set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppMetadataPropertyInfo;
+typedef struct Il2CppMetadataEventInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} Il2CppMetadataEventInfo;
+typedef struct Il2CppInterfaceOffsetInfo
+{
+    const Il2CppType* interfaceType;
+    int32_t offset;
+} Il2CppInterfaceOffsetInfo;
+typedef struct Il2CppGenericParameterInfo
+{
+    Il2CppMetadataGenericContainerHandle containerHandle;
+    const char* name;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameterInfo;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeHandleHashTable Il2CppNameToTypeHandleHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex __klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex __methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex __methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        Il2CppMetadataMethodDefinitionHandle methodMetadataHandle;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        Il2CppMetadataGenericContainerHandle genericContainerHandle;
+        Il2CppMethodPointer nativeFunction;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    uint32_t typeCount;
+    uint32_t exportedTypeCount;
+    uint32_t customAttributeCount;
+    Il2CppMetadataImageHandle metadataHandle;
+    Il2CppNameToTypeHandleHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t __genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+    const CustomAttributesCacheGenerator* customAttributeCacheGenerator;
+    const Il2CppMethodPointer moduleInitializer;
+    TypeDefinitionIndex* staticConstructorTypeIndices;
+    const Il2CppMetadataRegistration* metadataRegistration;
+    const Il2CppCodeRegistration* codeRegistaration;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject* type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/headers/2020.3.36f1.h
+++ b/headers/2020.3.36f1.h
@@ -1,0 +1,2365 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_GC_MODE_DISABLED = 0,
+    IL2CPP_GC_MODE_ENABLED = 1,
+    IL2CPP_GC_MODE_MANUAL = 2
+} Il2CppGCMode;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+    uintptr_t raw_ip;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint16_t Il2CppMethodSlot;
+static const uint16_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+typedef int32_t TypeFieldIndex;
+typedef int32_t TypeMethodIndex;
+typedef int32_t MethodParameterIndex;
+typedef int32_t TypePropertyIndex;
+typedef int32_t TypeEventIndex;
+typedef int32_t TypeInterfaceIndex;
+typedef int32_t TypeNestedTypeIndex;
+typedef int32_t TypeInterfaceOffsetIndex;
+typedef int32_t GenericContainerParameterIndex;
+typedef int32_t AssemblyTypeIndex;
+typedef int32_t AssemblyExportedTypeIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex __methodIndex;
+    TypeIndex __typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static inline uint32_t GetTokenType(uint32_t token)
+{
+    return token & 0xFF000000;
+}
+static inline uint32_t GetTokenRowId(uint32_t token)
+{
+    return token & 0x00FFFFFF;
+}
+typedef const struct ___Il2CppMetadataImageHandle* Il2CppMetadataImageHandle;
+typedef const struct ___Il2CppMetadataCustomAttributeHandle* Il2CppMetadataCustomAttributeHandle;
+typedef const struct ___Il2CppMetadataTypeHandle* Il2CppMetadataTypeHandle;
+typedef const struct ___Il2CppMetadataMethodHandle* Il2CppMetadataMethodDefinitionHandle;
+typedef const struct ___Il2CppMetadataGenericContainerHandle* Il2CppMetadataGenericContainerHandle;
+typedef const struct ___Il2CppMetadataGenericParameterHandle* Il2CppMetadataGenericParameterHandle;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppMetadataRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppMetadataRange;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralSize;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataSize;
+    int32_t stringOffset;
+    int32_t stringSize;
+    int32_t eventsOffset;
+    int32_t eventsSize;
+    int32_t propertiesOffset;
+    int32_t propertiesSize;
+    int32_t methodsOffset;
+    int32_t methodsSize;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesSize;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesSize;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataSize;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesSize;
+    int32_t parametersOffset;
+    int32_t parametersSize;
+    int32_t fieldsOffset;
+    int32_t fieldsSize;
+    int32_t genericParametersOffset;
+    int32_t genericParametersSize;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsSize;
+    int32_t genericContainersOffset;
+    int32_t genericContainersSize;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesSize;
+    int32_t interfacesOffset;
+    int32_t interfacesSize;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsSize;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsSize;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsSize;
+    int32_t imagesOffset;
+    int32_t imagesSize;
+    int32_t assembliesOffset;
+    int32_t assembliesSize;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsSize;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesSize;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoSize;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesSize;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesSize;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesSize;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t windowsRuntimeStringsOffset;
+    int32_t windowsRuntimeStringsSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsSize;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericClass
+{
+    const Il2CppType* type;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex __klassIndex;
+        Il2CppMetadataTypeHandle typeHandle;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex __genericParameterIndex;
+        Il2CppMetadataGenericParameterHandle genericParameterHandle;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppMetadataFieldInfo
+{
+    const Il2CppType* type;
+    const char* name;
+    uint32_t token;
+} Il2CppMetadataFieldInfo;
+typedef struct Il2CppMetadataMethodInfo
+{
+    Il2CppMetadataMethodDefinitionHandle handle;
+    const char* name;
+    const Il2CppType* return_type;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMetadataMethodInfo;
+typedef struct Il2CppMetadataParameterInfo
+{
+    const char* name;
+    uint32_t token;
+    const Il2CppType* type;
+} Il2CppMetadataParameterInfo;
+typedef struct Il2CppMetadataPropertyInfo
+{
+    const char* name;
+    const MethodInfo* get;
+    const MethodInfo* set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppMetadataPropertyInfo;
+typedef struct Il2CppMetadataEventInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} Il2CppMetadataEventInfo;
+typedef struct Il2CppInterfaceOffsetInfo
+{
+    const Il2CppType* interfaceType;
+    int32_t offset;
+} Il2CppInterfaceOffsetInfo;
+typedef struct Il2CppGenericParameterInfo
+{
+    Il2CppMetadataGenericContainerHandle containerHandle;
+    const char* name;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameterInfo;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeHandleHashTable Il2CppNameToTypeHandleHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex __klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex __methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex __methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        Il2CppMetadataMethodDefinitionHandle methodMetadataHandle;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        Il2CppMetadataGenericContainerHandle genericContainerHandle;
+        Il2CppMethodPointer nativeFunction;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    uint32_t typeCount;
+    uint32_t exportedTypeCount;
+    uint32_t customAttributeCount;
+    Il2CppMetadataImageHandle metadataHandle;
+    Il2CppNameToTypeHandleHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t __genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+    const CustomAttributesCacheGenerator* customAttributeCacheGenerator;
+    const Il2CppMethodPointer moduleInitializer;
+    TypeDefinitionIndex* staticConstructorTypeIndices;
+    const Il2CppMetadataRegistration* metadataRegistration;
+    const Il2CppCodeRegistration* codeRegistaration;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject* type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/headers/2020.3.37f1.h
+++ b/headers/2020.3.37f1.h
@@ -1,0 +1,2365 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_GC_MODE_DISABLED = 0,
+    IL2CPP_GC_MODE_ENABLED = 1,
+    IL2CPP_GC_MODE_MANUAL = 2
+} Il2CppGCMode;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+    uintptr_t raw_ip;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint16_t Il2CppMethodSlot;
+static const uint16_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+typedef int32_t TypeFieldIndex;
+typedef int32_t TypeMethodIndex;
+typedef int32_t MethodParameterIndex;
+typedef int32_t TypePropertyIndex;
+typedef int32_t TypeEventIndex;
+typedef int32_t TypeInterfaceIndex;
+typedef int32_t TypeNestedTypeIndex;
+typedef int32_t TypeInterfaceOffsetIndex;
+typedef int32_t GenericContainerParameterIndex;
+typedef int32_t AssemblyTypeIndex;
+typedef int32_t AssemblyExportedTypeIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex __methodIndex;
+    TypeIndex __typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static inline uint32_t GetTokenType(uint32_t token)
+{
+    return token & 0xFF000000;
+}
+static inline uint32_t GetTokenRowId(uint32_t token)
+{
+    return token & 0x00FFFFFF;
+}
+typedef const struct ___Il2CppMetadataImageHandle* Il2CppMetadataImageHandle;
+typedef const struct ___Il2CppMetadataCustomAttributeHandle* Il2CppMetadataCustomAttributeHandle;
+typedef const struct ___Il2CppMetadataTypeHandle* Il2CppMetadataTypeHandle;
+typedef const struct ___Il2CppMetadataMethodHandle* Il2CppMetadataMethodDefinitionHandle;
+typedef const struct ___Il2CppMetadataGenericContainerHandle* Il2CppMetadataGenericContainerHandle;
+typedef const struct ___Il2CppMetadataGenericParameterHandle* Il2CppMetadataGenericParameterHandle;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppMetadataRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppMetadataRange;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralSize;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataSize;
+    int32_t stringOffset;
+    int32_t stringSize;
+    int32_t eventsOffset;
+    int32_t eventsSize;
+    int32_t propertiesOffset;
+    int32_t propertiesSize;
+    int32_t methodsOffset;
+    int32_t methodsSize;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesSize;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesSize;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataSize;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesSize;
+    int32_t parametersOffset;
+    int32_t parametersSize;
+    int32_t fieldsOffset;
+    int32_t fieldsSize;
+    int32_t genericParametersOffset;
+    int32_t genericParametersSize;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsSize;
+    int32_t genericContainersOffset;
+    int32_t genericContainersSize;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesSize;
+    int32_t interfacesOffset;
+    int32_t interfacesSize;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsSize;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsSize;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsSize;
+    int32_t imagesOffset;
+    int32_t imagesSize;
+    int32_t assembliesOffset;
+    int32_t assembliesSize;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsSize;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesSize;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoSize;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesSize;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesSize;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesSize;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t windowsRuntimeStringsOffset;
+    int32_t windowsRuntimeStringsSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsSize;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericClass
+{
+    const Il2CppType* type;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex __klassIndex;
+        Il2CppMetadataTypeHandle typeHandle;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex __genericParameterIndex;
+        Il2CppMetadataGenericParameterHandle genericParameterHandle;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppMetadataFieldInfo
+{
+    const Il2CppType* type;
+    const char* name;
+    uint32_t token;
+} Il2CppMetadataFieldInfo;
+typedef struct Il2CppMetadataMethodInfo
+{
+    Il2CppMetadataMethodDefinitionHandle handle;
+    const char* name;
+    const Il2CppType* return_type;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMetadataMethodInfo;
+typedef struct Il2CppMetadataParameterInfo
+{
+    const char* name;
+    uint32_t token;
+    const Il2CppType* type;
+} Il2CppMetadataParameterInfo;
+typedef struct Il2CppMetadataPropertyInfo
+{
+    const char* name;
+    const MethodInfo* get;
+    const MethodInfo* set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppMetadataPropertyInfo;
+typedef struct Il2CppMetadataEventInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} Il2CppMetadataEventInfo;
+typedef struct Il2CppInterfaceOffsetInfo
+{
+    const Il2CppType* interfaceType;
+    int32_t offset;
+} Il2CppInterfaceOffsetInfo;
+typedef struct Il2CppGenericParameterInfo
+{
+    Il2CppMetadataGenericContainerHandle containerHandle;
+    const char* name;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameterInfo;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeHandleHashTable Il2CppNameToTypeHandleHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex __klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex __methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex __methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        Il2CppMetadataMethodDefinitionHandle methodMetadataHandle;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        Il2CppMetadataGenericContainerHandle genericContainerHandle;
+        Il2CppMethodPointer nativeFunction;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    uint32_t typeCount;
+    uint32_t exportedTypeCount;
+    uint32_t customAttributeCount;
+    Il2CppMetadataImageHandle metadataHandle;
+    Il2CppNameToTypeHandleHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t __genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+    const CustomAttributesCacheGenerator* customAttributeCacheGenerator;
+    const Il2CppMethodPointer moduleInitializer;
+    TypeDefinitionIndex* staticConstructorTypeIndices;
+    const Il2CppMetadataRegistration* metadataRegistration;
+    const Il2CppCodeRegistration* codeRegistaration;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject* type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/headers/2020.3.38f1.h
+++ b/headers/2020.3.38f1.h
@@ -1,0 +1,2365 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_GC_MODE_DISABLED = 0,
+    IL2CPP_GC_MODE_ENABLED = 1,
+    IL2CPP_GC_MODE_MANUAL = 2
+} Il2CppGCMode;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+    uintptr_t raw_ip;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint16_t Il2CppMethodSlot;
+static const uint16_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+typedef int32_t TypeFieldIndex;
+typedef int32_t TypeMethodIndex;
+typedef int32_t MethodParameterIndex;
+typedef int32_t TypePropertyIndex;
+typedef int32_t TypeEventIndex;
+typedef int32_t TypeInterfaceIndex;
+typedef int32_t TypeNestedTypeIndex;
+typedef int32_t TypeInterfaceOffsetIndex;
+typedef int32_t GenericContainerParameterIndex;
+typedef int32_t AssemblyTypeIndex;
+typedef int32_t AssemblyExportedTypeIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex __methodIndex;
+    TypeIndex __typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static inline uint32_t GetTokenType(uint32_t token)
+{
+    return token & 0xFF000000;
+}
+static inline uint32_t GetTokenRowId(uint32_t token)
+{
+    return token & 0x00FFFFFF;
+}
+typedef const struct ___Il2CppMetadataImageHandle* Il2CppMetadataImageHandle;
+typedef const struct ___Il2CppMetadataCustomAttributeHandle* Il2CppMetadataCustomAttributeHandle;
+typedef const struct ___Il2CppMetadataTypeHandle* Il2CppMetadataTypeHandle;
+typedef const struct ___Il2CppMetadataMethodHandle* Il2CppMetadataMethodDefinitionHandle;
+typedef const struct ___Il2CppMetadataGenericContainerHandle* Il2CppMetadataGenericContainerHandle;
+typedef const struct ___Il2CppMetadataGenericParameterHandle* Il2CppMetadataGenericParameterHandle;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppMetadataRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppMetadataRange;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralSize;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataSize;
+    int32_t stringOffset;
+    int32_t stringSize;
+    int32_t eventsOffset;
+    int32_t eventsSize;
+    int32_t propertiesOffset;
+    int32_t propertiesSize;
+    int32_t methodsOffset;
+    int32_t methodsSize;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesSize;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesSize;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataSize;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesSize;
+    int32_t parametersOffset;
+    int32_t parametersSize;
+    int32_t fieldsOffset;
+    int32_t fieldsSize;
+    int32_t genericParametersOffset;
+    int32_t genericParametersSize;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsSize;
+    int32_t genericContainersOffset;
+    int32_t genericContainersSize;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesSize;
+    int32_t interfacesOffset;
+    int32_t interfacesSize;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsSize;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsSize;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsSize;
+    int32_t imagesOffset;
+    int32_t imagesSize;
+    int32_t assembliesOffset;
+    int32_t assembliesSize;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsSize;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesSize;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoSize;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesSize;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesSize;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesSize;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t windowsRuntimeStringsOffset;
+    int32_t windowsRuntimeStringsSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsSize;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericClass
+{
+    const Il2CppType* type;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex __klassIndex;
+        Il2CppMetadataTypeHandle typeHandle;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex __genericParameterIndex;
+        Il2CppMetadataGenericParameterHandle genericParameterHandle;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppMetadataFieldInfo
+{
+    const Il2CppType* type;
+    const char* name;
+    uint32_t token;
+} Il2CppMetadataFieldInfo;
+typedef struct Il2CppMetadataMethodInfo
+{
+    Il2CppMetadataMethodDefinitionHandle handle;
+    const char* name;
+    const Il2CppType* return_type;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMetadataMethodInfo;
+typedef struct Il2CppMetadataParameterInfo
+{
+    const char* name;
+    uint32_t token;
+    const Il2CppType* type;
+} Il2CppMetadataParameterInfo;
+typedef struct Il2CppMetadataPropertyInfo
+{
+    const char* name;
+    const MethodInfo* get;
+    const MethodInfo* set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppMetadataPropertyInfo;
+typedef struct Il2CppMetadataEventInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} Il2CppMetadataEventInfo;
+typedef struct Il2CppInterfaceOffsetInfo
+{
+    const Il2CppType* interfaceType;
+    int32_t offset;
+} Il2CppInterfaceOffsetInfo;
+typedef struct Il2CppGenericParameterInfo
+{
+    Il2CppMetadataGenericContainerHandle containerHandle;
+    const char* name;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameterInfo;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeHandleHashTable Il2CppNameToTypeHandleHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex __klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex __methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex __methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        Il2CppMetadataMethodDefinitionHandle methodMetadataHandle;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        Il2CppMetadataGenericContainerHandle genericContainerHandle;
+        Il2CppMethodPointer nativeFunction;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    uint32_t typeCount;
+    uint32_t exportedTypeCount;
+    uint32_t customAttributeCount;
+    Il2CppMetadataImageHandle metadataHandle;
+    Il2CppNameToTypeHandleHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t __genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+    const CustomAttributesCacheGenerator* customAttributeCacheGenerator;
+    const Il2CppMethodPointer moduleInitializer;
+    TypeDefinitionIndex* staticConstructorTypeIndices;
+    const Il2CppMetadataRegistration* metadataRegistration;
+    const Il2CppCodeRegistration* codeRegistaration;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject* type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/headers/2020.3.39f1.h
+++ b/headers/2020.3.39f1.h
@@ -1,0 +1,2365 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_GC_MODE_DISABLED = 0,
+    IL2CPP_GC_MODE_ENABLED = 1,
+    IL2CPP_GC_MODE_MANUAL = 2
+} Il2CppGCMode;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+    uintptr_t raw_ip;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint16_t Il2CppMethodSlot;
+static const uint16_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+typedef int32_t TypeFieldIndex;
+typedef int32_t TypeMethodIndex;
+typedef int32_t MethodParameterIndex;
+typedef int32_t TypePropertyIndex;
+typedef int32_t TypeEventIndex;
+typedef int32_t TypeInterfaceIndex;
+typedef int32_t TypeNestedTypeIndex;
+typedef int32_t TypeInterfaceOffsetIndex;
+typedef int32_t GenericContainerParameterIndex;
+typedef int32_t AssemblyTypeIndex;
+typedef int32_t AssemblyExportedTypeIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex __methodIndex;
+    TypeIndex __typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static inline uint32_t GetTokenType(uint32_t token)
+{
+    return token & 0xFF000000;
+}
+static inline uint32_t GetTokenRowId(uint32_t token)
+{
+    return token & 0x00FFFFFF;
+}
+typedef const struct ___Il2CppMetadataImageHandle* Il2CppMetadataImageHandle;
+typedef const struct ___Il2CppMetadataCustomAttributeHandle* Il2CppMetadataCustomAttributeHandle;
+typedef const struct ___Il2CppMetadataTypeHandle* Il2CppMetadataTypeHandle;
+typedef const struct ___Il2CppMetadataMethodHandle* Il2CppMetadataMethodDefinitionHandle;
+typedef const struct ___Il2CppMetadataGenericContainerHandle* Il2CppMetadataGenericContainerHandle;
+typedef const struct ___Il2CppMetadataGenericParameterHandle* Il2CppMetadataGenericParameterHandle;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+} Il2CppMetadataUsage;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppMetadataRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppMetadataRange;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralSize;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataSize;
+    int32_t stringOffset;
+    int32_t stringSize;
+    int32_t eventsOffset;
+    int32_t eventsSize;
+    int32_t propertiesOffset;
+    int32_t propertiesSize;
+    int32_t methodsOffset;
+    int32_t methodsSize;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesSize;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesSize;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataSize;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesSize;
+    int32_t parametersOffset;
+    int32_t parametersSize;
+    int32_t fieldsOffset;
+    int32_t fieldsSize;
+    int32_t genericParametersOffset;
+    int32_t genericParametersSize;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsSize;
+    int32_t genericContainersOffset;
+    int32_t genericContainersSize;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesSize;
+    int32_t interfacesOffset;
+    int32_t interfacesSize;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsSize;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsSize;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsSize;
+    int32_t imagesOffset;
+    int32_t imagesSize;
+    int32_t assembliesOffset;
+    int32_t assembliesSize;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsSize;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesSize;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoSize;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesSize;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesSize;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesSize;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t windowsRuntimeStringsOffset;
+    int32_t windowsRuntimeStringsSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsSize;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericClass
+{
+    const Il2CppType* type;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex __klassIndex;
+        Il2CppMetadataTypeHandle typeHandle;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex __genericParameterIndex;
+        Il2CppMetadataGenericParameterHandle genericParameterHandle;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppMetadataFieldInfo
+{
+    const Il2CppType* type;
+    const char* name;
+    uint32_t token;
+} Il2CppMetadataFieldInfo;
+typedef struct Il2CppMetadataMethodInfo
+{
+    Il2CppMetadataMethodDefinitionHandle handle;
+    const char* name;
+    const Il2CppType* return_type;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMetadataMethodInfo;
+typedef struct Il2CppMetadataParameterInfo
+{
+    const char* name;
+    uint32_t token;
+    const Il2CppType* type;
+} Il2CppMetadataParameterInfo;
+typedef struct Il2CppMetadataPropertyInfo
+{
+    const char* name;
+    const MethodInfo* get;
+    const MethodInfo* set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppMetadataPropertyInfo;
+typedef struct Il2CppMetadataEventInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} Il2CppMetadataEventInfo;
+typedef struct Il2CppInterfaceOffsetInfo
+{
+    const Il2CppType* interfaceType;
+    int32_t offset;
+} Il2CppInterfaceOffsetInfo;
+typedef struct Il2CppGenericParameterInfo
+{
+    Il2CppMetadataGenericContainerHandle containerHandle;
+    const char* name;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameterInfo;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeHandleHashTable Il2CppNameToTypeHandleHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex __klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex __methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex __methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        Il2CppMetadataMethodDefinitionHandle methodMetadataHandle;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        Il2CppMetadataGenericContainerHandle genericContainerHandle;
+        Il2CppMethodPointer nativeFunction;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    uint32_t typeCount;
+    uint32_t exportedTypeCount;
+    uint32_t customAttributeCount;
+    Il2CppMetadataImageHandle metadataHandle;
+    Il2CppNameToTypeHandleHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t __genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+    const CustomAttributesCacheGenerator* customAttributeCacheGenerator;
+    const Il2CppMethodPointer moduleInitializer;
+    TypeDefinitionIndex* staticConstructorTypeIndices;
+    const Il2CppMetadataRegistration* metadataRegistration;
+    const Il2CppCodeRegistration* codeRegistaration;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject* type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/headers/2021.3.10f1.h
+++ b/headers/2021.3.10f1.h
@@ -1,0 +1,2422 @@
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppThread Il2CppThread;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_GC_MODE_DISABLED = 0,
+    IL2CPP_GC_MODE_ENABLED = 1,
+    IL2CPP_GC_MODE_MANUAL = 2
+} Il2CppGCMode;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+    uintptr_t raw_ip;
+    int sourceCodeLineNumber;
+    int ilOffset;
+    const char* filePath;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void* (*il2cpp_liveness_reallocate_callback)(void* ptr, size_t size, void* userdata);
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef void ( *CultureInfoChangedCallback)(const Il2CppChar* arg);
+typedef uint16_t Il2CppMethodSlot;
+static const uint16_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+typedef enum
+{
+    IL2CPP_TOKEN_MODULE = 0x00000000,
+    IL2CPP_TOKEN_TYPE_REF = 0x01000000,
+    IL2CPP_TOKEN_TYPE_DEF = 0x02000000,
+    IL2CPP_TOKEN_FIELD_DEF = 0x04000000,
+    IL2CPP_TOKEN_METHOD_DEF = 0x06000000,
+    IL2CPP_TOKEN_PARAM_DEF = 0x08000000,
+    IL2CPP_TOKEN_INTERFACE_IMPL = 0x09000000,
+    IL2CPP_TOKEN_MEMBER_REF = 0x0a000000,
+    IL2CPP_TOKEN_CUSTOM_ATTRIBUTE = 0x0c000000,
+    IL2CPP_TOKEN_PERMISSION = 0x0e000000,
+    IL2CPP_TOKEN_SIGNATURE = 0x11000000,
+    IL2CPP_TOKEN_EVENT = 0x14000000,
+    IL2CPP_TOKEN_PROPERTY = 0x17000000,
+    IL2CPP_TOKEN_MODULE_REF = 0x1a000000,
+    IL2CPP_TOKEN_TYPE_SPEC = 0x1b000000,
+    IL2CPP_TOKEN_ASSEMBLY = 0x20000000,
+    IL2CPP_TOKEN_ASSEMBLY_REF = 0x23000000,
+    IL2CPP_TOKEN_FILE = 0x26000000,
+    IL2CPP_TOKEN_EXPORTED_TYPE = 0x27000000,
+    IL2CPP_TOKEN_MANIFEST_RESOURCE = 0x28000000,
+    IL2CPP_TOKEN_GENERIC_PARAM = 0x2a000000,
+    IL2CPP_TOKEN_METHOD_SPEC = 0x2b000000,
+} Il2CppTokenType;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+typedef int32_t TypeFieldIndex;
+typedef int32_t TypeMethodIndex;
+typedef int32_t MethodParameterIndex;
+typedef int32_t TypePropertyIndex;
+typedef int32_t TypeEventIndex;
+typedef int32_t TypeInterfaceIndex;
+typedef int32_t TypeNestedTypeIndex;
+typedef int32_t TypeInterfaceOffsetIndex;
+typedef int32_t GenericContainerParameterIndex;
+typedef int32_t AssemblyTypeIndex;
+typedef int32_t AssemblyExportedTypeIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+static const int kPublicKeyByteLength = 8;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+    IL2CPP_RGCTX_DATA_CONSTRAINED,
+} Il2CppRGCTXDataType;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex __methodIndex;
+    TypeIndex __typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef struct Il2CppRGCTXConstrainedData
+{
+    TypeIndex __typeIndex;
+    uint32_t __encodedMethodIndex;
+} Il2CppRGCTXConstrainedData;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    const void* data;
+} Il2CppRGCTXDefinition;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex adjustorThunkIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+static inline uint32_t GetTokenType(uint32_t token)
+{
+    return token & 0xFF000000;
+}
+static inline uint32_t GetTokenRowId(uint32_t token)
+{
+    return token & 0x00FFFFFF;
+}
+typedef const struct ___Il2CppMetadataImageHandle* Il2CppMetadataImageHandle;
+typedef const struct ___Il2CppMetadataCustomAttributeHandle* Il2CppMetadataCustomAttributeHandle;
+typedef const struct ___Il2CppMetadataTypeHandle* Il2CppMetadataTypeHandle;
+typedef const struct ___Il2CppMetadataMethodHandle* Il2CppMetadataMethodDefinitionHandle;
+typedef const struct ___Il2CppMetadataGenericContainerHandle* Il2CppMetadataGenericContainerHandle;
+typedef const struct ___Il2CppMetadataGenericParameterHandle* Il2CppMetadataGenericParameterHandle;
+typedef uint32_t EncodedMethodIndex;
+typedef enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+    kIl2CppMetadataUsageFieldRva
+} Il2CppMetadataUsage;
+typedef enum Il2CppInvalidMetadataUsageToken
+{
+    kIl2CppInvalidMetadataUsageNoData = 0,
+    kIl2CppInvalidMetadataUsageAmbiguousMethod = 1,
+} Il2CppInvalidMetadataUsageToken;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppCustomAttributeDataRange
+{
+    uint32_t token;
+    uint32_t startOffset;
+} Il2CppCustomAttributeDataRange;
+typedef struct Il2CppMetadataRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppMetadataRange;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralSize;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataSize;
+    int32_t stringOffset;
+    int32_t stringSize;
+    int32_t eventsOffset;
+    int32_t eventsSize;
+    int32_t propertiesOffset;
+    int32_t propertiesSize;
+    int32_t methodsOffset;
+    int32_t methodsSize;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesSize;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesSize;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataSize;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesSize;
+    int32_t parametersOffset;
+    int32_t parametersSize;
+    int32_t fieldsOffset;
+    int32_t fieldsSize;
+    int32_t genericParametersOffset;
+    int32_t genericParametersSize;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsSize;
+    int32_t genericContainersOffset;
+    int32_t genericContainersSize;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesSize;
+    int32_t interfacesOffset;
+    int32_t interfacesSize;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsSize;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsSize;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsSize;
+    int32_t imagesOffset;
+    int32_t imagesSize;
+    int32_t assembliesOffset;
+    int32_t assembliesSize;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsSize;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesSize;
+    int32_t attributeDataOffset;
+    int32_t attributeDataSize;
+    int32_t attributeDataRangeOffset;
+    int32_t attributeDataRangeSize;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesSize;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesSize;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t windowsRuntimeStringsOffset;
+    int32_t windowsRuntimeStringsSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsSize;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppMetadataField
+{
+    uint32_t offset;
+    uint32_t typeIndex;
+    const char* name;
+    uint8_t isStatic;
+} Il2CppMetadataField;
+typedef enum Il2CppMetadataTypeFlags
+{
+    kNone = 0,
+    kValueType = 1 << 0,
+    kArray = 1 << 1,
+    kArrayRankMask = 0xFFFF0000
+} Il2CppMetadataTypeFlags;
+typedef struct Il2CppMetadataType
+{
+    Il2CppMetadataTypeFlags flags;
+    Il2CppMetadataField* fields;
+    uint32_t fieldCount;
+    uint32_t staticsSize;
+    uint8_t* statics;
+    uint32_t baseOrElementTypeIndex;
+    char* name;
+    const char* assemblyName;
+    uint64_t typeInfoAddress;
+    uint32_t size;
+} Il2CppMetadataType;
+typedef struct Il2CppMetadataSnapshot
+{
+    uint32_t typeCount;
+    Il2CppMetadataType* types;
+} Il2CppMetadataSnapshot;
+typedef struct Il2CppManagedMemorySection
+{
+    uint64_t sectionStartAddress;
+    uint32_t sectionSize;
+    uint8_t* sectionBytes;
+} Il2CppManagedMemorySection;
+typedef struct Il2CppManagedHeap
+{
+    uint32_t sectionCount;
+    Il2CppManagedMemorySection* sections;
+} Il2CppManagedHeap;
+typedef struct Il2CppStacks
+{
+    uint32_t stackCount;
+    Il2CppManagedMemorySection* stacks;
+} Il2CppStacks;
+typedef struct NativeObject
+{
+    uint32_t gcHandleIndex;
+    uint32_t size;
+    uint32_t instanceId;
+    uint32_t classId;
+    uint32_t referencedNativeObjectIndicesCount;
+    uint32_t* referencedNativeObjectIndices;
+} NativeObject;
+typedef struct Il2CppGCHandles
+{
+    uint32_t trackedObjectCount;
+    uint64_t* pointersToObjects;
+} Il2CppGCHandles;
+typedef struct Il2CppRuntimeInformation
+{
+    uint32_t pointerSize;
+    uint32_t objectHeaderSize;
+    uint32_t arrayHeaderSize;
+    uint32_t arrayBoundsOffsetInHeader;
+    uint32_t arraySizeOffsetInHeader;
+    uint32_t allocationGranularity;
+} Il2CppRuntimeInformation;
+typedef struct Il2CppManagedMemorySnapshot
+{
+    Il2CppManagedHeap heap;
+    Il2CppStacks stacks;
+    Il2CppMetadataSnapshot metadata;
+    Il2CppGCHandles gcHandles;
+    Il2CppRuntimeInformation runtimeInformation;
+    void* additionalUserInformation;
+} Il2CppManagedMemorySnapshot;
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55,
+    IL2CPP_TYPE_IL2CPP_TYPE_INDEX = 0xff
+} Il2CppTypeEnum;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericClass
+{
+    const Il2CppType* type;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex __klassIndex;
+        Il2CppMetadataTypeHandle typeHandle;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex __genericParameterIndex;
+        Il2CppMetadataGenericParameterHandle genericParameterHandle;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 5;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+    unsigned int valuetype : 1;
+} Il2CppType;
+typedef struct Il2CppMetadataFieldInfo
+{
+    const Il2CppType* type;
+    const char* name;
+    uint32_t token;
+} Il2CppMetadataFieldInfo;
+typedef struct Il2CppMetadataMethodInfo
+{
+    Il2CppMetadataMethodDefinitionHandle handle;
+    const char* name;
+    const Il2CppType* return_type;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMetadataMethodInfo;
+typedef struct Il2CppMetadataParameterInfo
+{
+    const char* name;
+    uint32_t token;
+    const Il2CppType* type;
+} Il2CppMetadataParameterInfo;
+typedef struct Il2CppMetadataPropertyInfo
+{
+    const char* name;
+    const MethodInfo* get;
+    const MethodInfo* set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppMetadataPropertyInfo;
+typedef struct Il2CppMetadataEventInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} Il2CppMetadataEventInfo;
+typedef struct Il2CppInterfaceOffsetInfo
+{
+    const Il2CppType* interfaceType;
+    int32_t offset;
+} Il2CppInterfaceOffsetInfo;
+typedef struct Il2CppGenericParameterInfo
+{
+    Il2CppMetadataGenericContainerHandle containerHandle;
+    const char* name;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameterInfo;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppHString__
+{
+    int unused;
+} Il2CppHString__;
+typedef Il2CppHString__* Il2CppHString;
+typedef struct Il2CppHStringHeader
+{
+    union
+    {
+        void* Reserved1;
+        char Reserved2[24];
+    } Reserved;
+} Il2CppHStringHeader;
+typedef struct Il2CppGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+} Il2CppGuid;
+typedef struct Il2CppSafeArrayBound
+{
+    uint32_t element_count;
+    int32_t lower_bound;
+} Il2CppSafeArrayBound;
+typedef struct Il2CppSafeArray
+{
+    uint16_t dimension_count;
+    uint16_t features;
+    uint32_t element_size;
+    uint32_t lock_count;
+    void* data;
+    Il2CppSafeArrayBound bounds[1];
+} Il2CppSafeArray;
+typedef struct Il2CppWin32Decimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } s;
+        uint16_t signscale;
+    } u;
+    uint32_t hi32;
+    union
+    {
+        struct
+        {
+            uint32_t lo32;
+            uint32_t mid32;
+        } s2;
+        uint64_t lo64;
+    } u2;
+} Il2CppWin32Decimal;
+typedef int16_t IL2CPP_VARIANT_BOOL;
+typedef enum Il2CppVarType
+{
+    IL2CPP_VT_EMPTY = 0,
+    IL2CPP_VT_NULL = 1,
+    IL2CPP_VT_I2 = 2,
+    IL2CPP_VT_I4 = 3,
+    IL2CPP_VT_R4 = 4,
+    IL2CPP_VT_R8 = 5,
+    IL2CPP_VT_CY = 6,
+    IL2CPP_VT_DATE = 7,
+    IL2CPP_VT_BSTR = 8,
+    IL2CPP_VT_DISPATCH = 9,
+    IL2CPP_VT_ERROR = 10,
+    IL2CPP_VT_BOOL = 11,
+    IL2CPP_VT_VARIANT = 12,
+    IL2CPP_VT_UNKNOWN = 13,
+    IL2CPP_VT_DECIMAL = 14,
+    IL2CPP_VT_I1 = 16,
+    IL2CPP_VT_UI1 = 17,
+    IL2CPP_VT_UI2 = 18,
+    IL2CPP_VT_UI4 = 19,
+    IL2CPP_VT_I8 = 20,
+    IL2CPP_VT_UI8 = 21,
+    IL2CPP_VT_INT = 22,
+    IL2CPP_VT_UINT = 23,
+    IL2CPP_VT_VOID = 24,
+    IL2CPP_VT_HRESULT = 25,
+    IL2CPP_VT_PTR = 26,
+    IL2CPP_VT_SAFEARRAY = 27,
+    IL2CPP_VT_CARRAY = 28,
+    IL2CPP_VT_USERDEFINED = 29,
+    IL2CPP_VT_LPSTR = 30,
+    IL2CPP_VT_LPWSTR = 31,
+    IL2CPP_VT_RECORD = 36,
+    IL2CPP_VT_INT_PTR = 37,
+    IL2CPP_VT_UINT_PTR = 38,
+    IL2CPP_VT_FILETIME = 64,
+    IL2CPP_VT_BLOB = 65,
+    IL2CPP_VT_STREAM = 66,
+    IL2CPP_VT_STORAGE = 67,
+    IL2CPP_VT_STREAMED_OBJECT = 68,
+    IL2CPP_VT_STORED_OBJECT = 69,
+    IL2CPP_VT_BLOB_OBJECT = 70,
+    IL2CPP_VT_CF = 71,
+    IL2CPP_VT_CLSID = 72,
+    IL2CPP_VT_VERSIONED_STREAM = 73,
+    IL2CPP_VT_BSTR_BLOB = 0xfff,
+    IL2CPP_VT_VECTOR = 0x1000,
+    IL2CPP_VT_ARRAY = 0x2000,
+    IL2CPP_VT_BYREF = 0x4000,
+    IL2CPP_VT_RESERVED = 0x8000,
+    IL2CPP_VT_ILLEGAL = 0xffff,
+    IL2CPP_VT_ILLEGALMASKED = 0xfff,
+    IL2CPP_VT_TYPEMASK = 0xfff,
+} Il2CppVarType;
+typedef struct Il2CppVariant Il2CppVariant;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppVariant
+{
+    union
+    {
+        struct __tagVARIANT
+        {
+            uint16_t type;
+            uint16_t reserved1;
+            uint16_t reserved2;
+            uint16_t reserved3;
+            union
+            {
+                int64_t llVal;
+                int32_t lVal;
+                uint8_t bVal;
+                int16_t iVal;
+                float fltVal;
+                double dblVal;
+                IL2CPP_VARIANT_BOOL boolVal;
+                int32_t scode;
+                int64_t cyVal;
+                double date;
+                Il2CppChar* bstrVal;
+                Il2CppIUnknown* punkVal;
+                void* pdispVal;
+                Il2CppSafeArray* parray;
+                uint8_t* pbVal;
+                int16_t* piVal;
+                int32_t* plVal;
+                int64_t* pllVal;
+                float* pfltVal;
+                double* pdblVal;
+                IL2CPP_VARIANT_BOOL* pboolVal;
+                int32_t* pscode;
+                int64_t* pcyVal;
+                double* pdate;
+                Il2CppChar* pbstrVal;
+                Il2CppIUnknown** ppunkVal;
+                void** ppdispVal;
+                Il2CppSafeArray** pparray;
+                struct Il2CppVariant* pvarVal;
+                void* byref;
+                char cVal;
+                uint16_t uiVal;
+                uint32_t ulVal;
+                uint64_t ullVal;
+                int intVal;
+                unsigned int uintVal;
+                Il2CppWin32Decimal* pdecVal;
+                char* pcVal;
+                uint16_t* puiVal;
+                uint32_t* pulVal;
+                uint64_t* pullVal;
+                int* pintVal;
+                unsigned int* puintVal;
+                struct __tagBRECORD
+                {
+                    void* pvRecord;
+                    void* pRecInfo;
+                } n4;
+            } n3;
+        } n2;
+        Il2CppWin32Decimal decVal;
+    } n1;
+} Il2CppVariant;
+typedef struct Il2CppFileTime
+{
+    uint32_t low;
+    uint32_t high;
+} Il2CppFileTime;
+typedef struct Il2CppStatStg
+{
+    Il2CppChar* name;
+    uint32_t type;
+    uint64_t size;
+    Il2CppFileTime mtime;
+    Il2CppFileTime ctime;
+    Il2CppFileTime atime;
+    uint32_t mode;
+    uint32_t locks;
+    Il2CppGuid clsid;
+    uint32_t state;
+    uint32_t reserved;
+} Il2CppStatStg;
+typedef enum Il2CppWindowsRuntimeTypeKind
+{
+    kTypeKindPrimitive = 0,
+    kTypeKindMetadata,
+    kTypeKindCustom
+} Il2CppWindowsRuntimeTypeKind;
+typedef struct Il2CppWindowsRuntimeTypeName
+{
+    Il2CppHString typeName;
+    enum Il2CppWindowsRuntimeTypeKind typeKind;
+} Il2CppWindowsRuntimeTypeName;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeHandleHashTable Il2CppNameToTypeHandleHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct Il2CppMetadataRegistration Il2CppMetadataRegistration;
+typedef struct Il2CppCodeRegistration Il2CppCodeRegistration;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppImage *corlib_gen;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *member_info_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *customattribute_typed_argument_class;
+    Il2CppClass *customattribute_named_argument_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+    Il2CppClass* il2cpp_fully_shared_type;
+    Il2CppClass* il2cpp_fully_shared_struct_type;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct MemberInfo MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef void (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**, void*);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex __klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex __methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex __methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int32_t tryId;
+    int32_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    Il2CppMethodPointer virtualMethodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const Il2CppType** parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        Il2CppMetadataMethodDefinitionHandle methodMetadataHandle;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t has_full_generic_sharing_signature : 1;
+    uint8_t indirect_call_via_invokers : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef struct Il2CppClass
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished_or_no_cctor;
+    __attribute__((aligned(8))) size_t cctor_thread;
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t nullabletype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t is_byref_like : 1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+
+typedef struct Il2CppClass_0 {
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass * generic_class;
+    Il2CppMetadataTypeHandle typeMetadataHandle;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+
+typedef struct Il2CppClass_1 {
+    struct Il2CppClass** typeHierarchy;
+    void * unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished_or_no_cctor;
+#ifdef IS_32BIT
+    uint32_t cctor_thread;
+#else
+    __attribute__((aligned(8))) size_t cctor_thread;
+#endif
+    Il2CppMetadataGenericContainerHandle genericContainerHandle;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t nullabletype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t is_byref_like : 1;
+} Il2CppClass_1;
+
+typedef struct __attribute__((aligned(8))) Il2CppClass_Merged {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass_Merged;
+
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    Il2CppObject* ephemeron_tombstone;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const uint8_t* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    uint32_t typeCount;
+    uint32_t exportedTypeCount;
+    uint32_t customAttributeCount;
+    Il2CppMetadataImageHandle metadataHandle;
+    Il2CppNameToTypeHandleHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+    int maximumRuntimeGenericDepth;
+    int recursiveGenericIterations;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t __genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppTokenAdjustorThunkPair
+{
+    uint32_t token;
+    Il2CppMethodPointer adjustorThunk;
+} Il2CppTokenAdjustorThunkPair;
+typedef struct Il2CppWindowsRuntimeFactoryTableEntry
+{
+    const Il2CppType* type;
+    Il2CppMethodPointer createFactoryFunction;
+} Il2CppWindowsRuntimeFactoryTableEntry;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const uint32_t adjustorThunkCount;
+    const Il2CppTokenAdjustorThunkPair* adjustorThunks;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+    const Il2CppMethodPointer moduleInitializer;
+    TypeDefinitionIndex* staticConstructorTypeIndices;
+    const Il2CppMetadataRegistration* metadataRegistration;
+    const Il2CppCodeRegistration* codeRegistaration;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    const Il2CppMethodPointer* genericAdjustorThunks;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t windowsRuntimeFactoryCount;
+    Il2CppWindowsRuntimeFactoryTableEntry* windowsRuntimeFactoryTable;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject* type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    uint32_t AttrsImpl;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    Il2CppObject* MarshalAs;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *evidence;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppThreadName
+{
+    Il2CppChar* chars;
+    int32_t unused;
+    int32_t length;
+} Il2CppThreadName;
+typedef struct
+{
+    uint32_t ref;
+    void (*destructor)(void* data);
+} Il2CppRefCount;
+typedef struct
+{
+    Il2CppRefCount ref;
+    void* synch_cs;
+} Il2CppLongLivedThreadData;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppThreadName name;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* longlived;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    void* unused[3];
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppThread
+{
+    Il2CppObject obj;
+    Il2CppInternalThread* internal_thread;
+    Il2CppObject* start_obj;
+    Il2CppException* pending_exception;
+    Il2CppObject* principal;
+    int32_t principal_version;
+    Il2CppDelegate* delegate;
+    Il2CppObject* executionContext;
+    uint8_t executionContextBelongsToOuterScope;
+} Il2CppThread;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    struct Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+    int32_t caught_in_unmanaged;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    Il2CppMethodPointer invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    Il2CppObject* invoke_impl_this;
+    void* interp_method;
+    void* interp_invoke_impl;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef void* Il2CppFullySharedGenericAny;
+typedef void* Il2CppFullySharedGenericStruct;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct NumberFormatEntryManaged
+{
+    int32_t currency_decimal_digits;
+    int32_t currency_decimal_separator;
+    int32_t currency_group_separator;
+    int32_t currency_group_sizes0;
+    int32_t currency_group_sizes1;
+    int32_t currency_negative_pattern;
+    int32_t currency_positive_pattern;
+    int32_t currency_symbol;
+    int32_t nan_symbol;
+    int32_t negative_infinity_symbol;
+    int32_t negative_sign;
+    int32_t number_decimal_digits;
+    int32_t number_decimal_separator;
+    int32_t number_group_separator;
+    int32_t number_group_sizes0;
+    int32_t number_group_sizes1;
+    int32_t number_negative_pattern;
+    int32_t per_mille_symbol;
+    int32_t percent_negative_pattern;
+    int32_t percent_positive_pattern;
+    int32_t percent_symbol;
+    int32_t positive_infinity_symbol;
+    int32_t positive_sign;
+} NumberFormatEntryManaged;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    struct Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;
+typedef struct Il2CppByReference
+{
+    intptr_t value;
+} Il2CppByReference;

--- a/headers/diffs.diff
+++ b/headers/diffs.diff
@@ -5442,7 +5442,7 @@
      };
      uint32_t token;
      uint16_t flags;
---- 2019.4.39f1.h
+--- 2019.4.40f1.h
 +++ 2020.1.0a3.h
 @@ -123,7 +123,6 @@ typedef void (*Il2CppProfileFileIOFunc)
  typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
@@ -6694,7 +6694,7 @@
  } Il2CppGlobalMetadataHeader;
  #pragma pack(pop, p1)
  typedef struct Il2CppMetadataField
---- 2020.3.34f1.h
+--- 2020.3.39f1.h
 +++ 2021.1.0a2.h
 @@ -88,6 +88,9 @@ typedef struct Il2CppStackFrameInfo
  {
@@ -7802,6 +7802,16 @@
      void* interp_invoke_impl;
      Il2CppReflectionMethod *method_info;
 --- 2021.3.2f1.h
++++ 2021.3.10f1.h
+@@ -282,6 +282,7 @@ typedef enum Il2CppMetadataUsage
+     kIl2CppMetadataUsageFieldInfo,
+     kIl2CppMetadataUsageStringLiteral,
+     kIl2CppMetadataUsageMethodRef,
++    kIl2CppMetadataUsageFieldRva
+ } Il2CppMetadataUsage;
+ typedef enum Il2CppInvalidMetadataUsageToken
+ {
+--- 2021.3.10f1.h
 +++ 2022.1.0a7.h
 @@ -137,7 +137,6 @@ typedef size_t(*Il2CppBacktraceFunc) (Il
  typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
@@ -7811,7 +7821,15 @@
  typedef uint16_t Il2CppMethodSlot;
  static const uint16_t kInvalidIl2CppMethodSlot = 65535;
  static const int ipv6AddressSize = 16;
-@@ -464,67 +463,67 @@ typedef struct Il2CppGlobalMetadataHeade
+@@ -282,7 +281,6 @@ typedef enum Il2CppMetadataUsage
+     kIl2CppMetadataUsageFieldInfo,
+     kIl2CppMetadataUsageStringLiteral,
+     kIl2CppMetadataUsageMethodRef,
+-    kIl2CppMetadataUsageFieldRva
+ } Il2CppMetadataUsage;
+ typedef enum Il2CppInvalidMetadataUsageToken
+ {
+@@ -465,67 +463,67 @@ typedef struct Il2CppGlobalMetadataHeade
      int32_t sanity;
      int32_t version;
      int32_t stringLiteralOffset;
@@ -7908,7 +7926,7 @@
  } Il2CppGlobalMetadataHeader;
  #pragma pack(pop, p1)
  typedef struct Il2CppMetadataField
-@@ -1114,7 +1113,6 @@ typedef struct Il2CppDefaults
+@@ -1115,7 +1113,6 @@ typedef struct Il2CppDefaults
      Il2CppClass* uint32_shared_enum;
      Il2CppClass* uint64_shared_enum;
      Il2CppClass* il2cpp_fully_shared_type;
@@ -7916,7 +7934,7 @@
  } Il2CppDefaults;
  extern Il2CppDefaults il2cpp_defaults;
  typedef struct Il2CppClass Il2CppClass;
-@@ -1267,7 +1265,6 @@ typedef struct MethodInfo
+@@ -1268,7 +1265,6 @@ typedef struct MethodInfo
      uint8_t is_inflated : 1;
      uint8_t wrapper_type : 1;
      uint8_t has_full_generic_sharing_signature : 1;
@@ -7924,7 +7942,7 @@
  } MethodInfo;
  typedef struct Il2CppRuntimeInterfaceOffsetPair
  {
-@@ -1336,7 +1333,6 @@ typedef struct Il2CppClass
+@@ -1337,7 +1333,6 @@ typedef struct Il2CppClass
      uint8_t is_generic : 1;
      uint8_t has_references : 1;
      uint8_t init_pending : 1;
@@ -7932,7 +7950,7 @@
      uint8_t size_inited : 1;
      uint8_t has_finalize : 1;
      uint8_t has_cctor : 1;
-@@ -1412,7 +1408,6 @@ typedef struct Il2CppClass_1 {
+@@ -1413,7 +1408,6 @@ typedef struct Il2CppClass_1 {
      uint8_t is_generic : 1;
      uint8_t has_references : 1;
      uint8_t init_pending : 1;
@@ -7940,7 +7958,7 @@
      uint8_t size_inited : 1;
      uint8_t has_finalize : 1;
      uint8_t has_cctor : 1;
-@@ -1443,7 +1438,6 @@ typedef struct Il2CppDomain
+@@ -1444,7 +1438,6 @@ typedef struct Il2CppDomain
      Il2CppAppDomain* domain;
      Il2CppAppDomainSetup* setup;
      Il2CppAppContext* default_context;
@@ -7948,7 +7966,7 @@
      const char* friendly_name;
      uint32_t domain_id;
      volatile int threadpool_jobs;
-@@ -1489,7 +1483,6 @@ typedef struct Il2CppCodeGenOptions
+@@ -1490,7 +1483,6 @@ typedef struct Il2CppCodeGenOptions
  {
      uint8_t enablePrimitiveValueTypeGenericSharing;
      int maximumRuntimeGenericDepth;
@@ -7956,7 +7974,7 @@
  } Il2CppCodeGenOptions;
  typedef struct Il2CppRange
  {
-@@ -2007,12 +2000,12 @@ typedef struct Il2CppDelegate
+@@ -2008,12 +2000,12 @@ typedef struct Il2CppDelegate
  {
      Il2CppObject object;
      Il2CppMethodPointer method_ptr;


### PR DESCRIPTION
These are the last versions I can dump. There's a problem in the extraction script which prevents me from dumping newer versions. I will not be looking into that. I have no need for IL2Cpp information. I've only maintained this as a favor to a friend. Having almost every Unity version that ever existed makes it relatively easy for me to dump the information en masse.

Edit: I discovered that the problem was not in the extraction script, but in faulty input. After deleting a handful of versions, I was able to dump the rest.